### PR TITLE
Feature/host retry support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Validate release metadata
         run: python scripts/validate-release.py
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
 
       - name: Validate release metadata
         run: python scripts/validate-release.py
@@ -61,6 +63,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
 
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.88.0
+          components: clippy,rustfmt
 
       - name: Validate release metadata
         run: python scripts/validate-release.py

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v4

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
 
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v4

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
@@ -218,7 +218,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Install maturin
         run: python -m pip install "maturin>=1,<2"

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -136,6 +136,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
@@ -215,6 +217,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
 
       - name: Install maturin
         run: python -m pip install "maturin>=1,<2"

--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Validate release
         env:

--- a/.github/workflows/publish-rust-crates.yml
+++ b/.github/workflows/publish-rust-crates.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.0
 
       - name: Validate release
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS
+
+Repository-specific instructions for AI coding agents working in this workspace.
+
+## Changelog Policy
+
+### Scope
+
+- This repository uses a single top-level `CHANGELOG.md`.
+- Do not create per-crate changelogs unless explicitly requested.
+- This repository follows Keep a Changelog style for `CHANGELOG.md`.
+
+### Format
+
+- Add entries under `Unreleased`.
+- Use user-facing headings such as:
+  - `Added`
+  - `Changed`
+  - `Fixed`
+  - `Removed`
+- Write changelog entries as release notes, not as commit-message text.
+- Mark breaking entries inline with `**Breaking:**` and include migration guidance in the same bullet.
+
+### Content
+
+- Include migration guidance for breaking changes.
+- Use `Refs: #<issue>` for linked work items when an issue exists.
+
+### Timing
+
+- Update `CHANGELOG.md` during the branch, not only at merge time.
+- Any user-visible or breaking change should update the changelog.
+
+## Testing
+
+### Python Rust-Backed Tests
+
+- For `genja-core-python`, run Rust-backed tests from the `genja-core-python` directory.
+- Use:
+  - `pdm run test-rust`
+- Prefer repo-documented test commands over ad hoc commands.
+
+## Commit Conventions
+
+### Format
+
+- Use Conventional Commits.
+- Mark breaking changes with `!`.
+
+### Breaking Changes
+
+- For breaking commits, include a `BREAKING CHANGE:` footer in the commit body when appropriate.
+- Breaking API, serialization, or result-shape changes must also be documented in `CHANGELOG.md`.
+
+## Documentation
+
+### User-Facing Changes
+
+- Update relevant docs when public behavior, APIs, settings, or result shapes change.
+- Do not leave user-visible behavior changes undocumented.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,20 @@ Repository-specific instructions for AI coding agents working in this workspace.
 - For `genja-core-python`, run Rust-backed tests from the `genja-core-python` directory.
 - Use:
   - `pdm run test-rust`
+- Use `pdm run test-rust` instead of invoking `cargo test -p genja-core-python` directly. The PDM wrapper runs Cargo through the project Python environment, sets the correct `PYO3_PYTHON` interpreter, and ensures PyO3-backed tests can access the installed Python packages.
+- Avoid launching multiple `genja-core-python` Rust-backed test commands concurrently from separate tool calls. Each run is already single-threaded internally, and concurrent invocations may hang or fail to return output reliably in this workspace.
 - Prefer repo-documented test commands over ad hoc commands.
+
+### Trybuild UI Tests
+
+- `genja-core/tests/ui_genja_task/**/*.stderr` are snapshot fixtures for trybuild compile-fail tests.
+- These snapshots are sensitive to Rust compiler diagnostic formatting. Drift is usually caused by `rustc` version changes, not by the feature change itself.
+- Do not edit trybuild `.stderr` files manually unless needed for a small targeted correction. Prefer refreshing them by rerunning the relevant test with `TRYBUILD=overwrite`.
+- Refresh trybuild snapshots only when:
+  - macro diagnostics intentionally changed, or
+  - the Rust toolchain changed and the emitted diagnostics legitimately drifted.
+- If trybuild fixtures changed, mention in the commit or PR that the snapshot refresh was due to diagnostic output drift or intentional diagnostic changes.
+- When adding new trybuild compile-fail fixtures, minimize unrelated warnings in the test case so snapshots are less brittle across toolchain updates.
 
 ## Commit Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ All notable changes to this workspace should be documented in this file.
 - **Breaking:** Redesigned `HostTaskResult` from an enum into a structured object with `outcome` and `execution_metadata`. Rust consumers should migrate direct enum variant matching to compatibility accessors or the new structured fields.
 - Python `HostTaskResult.to_dict()` now returns the new structured shape.
 - `HostTaskResult.status` remains available as a convenience accessor.
+- Added runner-level retry defaults through `allow_retries` and `max_task_attempts` in shared settings, plus task-level overrides in Rust and Python task metadata.
 
 Refs: #63

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,7 @@ All notable changes to this workspace should be documented in this file.
 - Python `HostTaskResult.to_dict()` now returns the new structured shape.
 - `HostTaskResult.status` remains available as a convenience accessor.
 - Added runner-level retry defaults through `allow_retries` and `max_task_attempts` in shared settings, plus task-level overrides in Rust and Python task metadata.
+- Built-in task execution now applies retry policy from runner settings and task metadata. Retries only occur for failures explicitly marked `retryable`, and host execution metadata now records attempts, whether a retry occurred, and whether retries were exhausted.
+- The workspace Rust toolchain is now pinned to `1.88.0` to align local diagnostics and trybuild snapshots with CI.
 
 Refs: #63

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this workspace should be documented in this file.
 
 - **Breaking:** Redesigned `HostTaskResult` from an enum into a structured object with `outcome` and `execution_metadata`. Rust consumers should migrate direct enum variant matching to compatibility accessors or the new structured fields.
 - **Breaking:** Removed duplicated host timing fields from `outcome.Passed` and `outcome.Failed` in human JSON serialization. Consumers should read host timing from `execution_metadata.started_at`, `execution_metadata.finished_at`, and `execution_metadata.duration` instead.
+- **Breaking:** Removed execution timing fields and accessors from `TaskSuccess` and `TaskFailure`. Rust consumers should read per-host timing from `HostTaskResult.execution_metadata()` and aggregate task timing from `TaskResults`.
 - Python `HostTaskResult.to_dict()` now returns the new structured shape.
 - `HostTaskResult.status` remains available as a convenience accessor.
 - Added runner-level retry defaults through `allow_retries` and `max_task_attempts` in shared settings, plus task-level overrides in Rust and Python task metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this workspace should be documented in this file.
+
+## Unreleased
+
+### Changed
+
+- **Breaking:** Redesigned `HostTaskResult` from an enum into a structured object with `outcome` and `execution_metadata`. Rust consumers should migrate direct enum variant matching to compatibility accessors or the new structured fields.
+- Python `HostTaskResult.to_dict()` now returns the new structured shape.
+- `HostTaskResult.status` remains available as a convenience accessor.
+
+Refs: #63

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this workspace should be documented in this file.
 ### Changed
 
 - **Breaking:** Redesigned `HostTaskResult` from an enum into a structured object with `outcome` and `execution_metadata`. Rust consumers should migrate direct enum variant matching to compatibility accessors or the new structured fields.
+- **Breaking:** Removed duplicated host timing fields from `outcome.Passed` and `outcome.Failed` in human JSON serialization. Consumers should read host timing from `execution_metadata.started_at`, `execution_metadata.finished_at`, and `execution_metadata.duration` instead.
 - Python `HostTaskResult.to_dict()` now returns the new structured shape.
 - `HostTaskResult.status` remains available as a convenience accessor.
 - Added runner-level retry defaults through `allow_retries` and `max_task_attempts` in shared settings, plus task-level overrides in Rust and Python task metadata.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,17 @@ pdm run typecheck
 pdm run test
 pdm run test-rust
 ```
+
+## Changelog And Compatibility
+
+- This repository uses a single top-level `CHANGELOG.md`.
+- This repository follows Keep a Changelog style for `CHANGELOG.md`.
+- Add user-visible changes under `Unreleased`.
+- Use release-note headings such as:
+  - `Added`
+  - `Changed`
+  - `Fixed`
+  - `Removed`
+- Mark breaking entries inline with `**Breaking:**` and include migration guidance in the same bullet.
+- Update the changelog during the branch, not only at merge time.
+- For linked work items, use `Refs: #<issue>` when an issue exists.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ let genja = Genja::builder(inventory).build()?;
 let results = genja.run_task(CheckConfigTask, 10)?;
 
 assert!(results.host_result("router1").unwrap().is_passed());
+
+let host_result = results.host_result("router1").unwrap();
+assert_eq!(host_result.status(), "passed");
+assert_eq!(host_result.execution_metadata().attempts(), 1);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
@@ -240,7 +244,9 @@ Notes:
 - `max_depth` limits recursive sub-task execution. A task with no sub-tasks can use a small value like `1`.
 - `#[genja_task(...)]` owns static task metadata like name, processors, and connection plugin selection.
 - `connection_plugin_name` is optional, but usually needed for real task execution.
-- Rich task output lives in `TaskSuccess`, `TaskFailure`, `TaskSkip`, and `TaskResults`.
+- Rich task output is split between semantic outcome payloads
+  (`TaskSuccess`, `TaskFailure`, `TaskSkip`) and host-level execution metadata on
+  `HostTaskResult`.
 - The lower-level task API is documented in `genja-core/src/task.rs`.
 
 ### Task Processor Plugins

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,11 +17,12 @@ development environment needs:
 
 ## Tool Versions
 
-The workspace includes Rust 2024 edition crates, so contributors should use
-Rust and Cargo 1.85.0 or newer.
+The workspace pins Rust and Cargo to 1.85.0 in `rust-toolchain.toml`. Use that
+toolchain locally so compiler diagnostics, formatting, and trybuild snapshots
+match CI.
 
-This is the contributor baseline for the current workspace. Individual crates do
-not currently declare a formal `rust-version` MSRV in their package metadata.
+Individual crates do not currently declare a formal `rust-version` MSRV in
+their package metadata.
 
 Python binding development requires Python 3.10 or newer, as declared by the
 `genja-py` package.
@@ -86,6 +87,34 @@ If a change touches shared runtime behavior, task execution, plugin loading, or
 public APIs, prefer running both the focused package tests and the Rust
 workspace test command above.
 
+### Trybuild UI Fixtures
+
+The derive macro compile-fail tests under `genja-core/tests/ui_genja_task/`
+use trybuild `.stderr` snapshot files.
+
+These snapshots are sensitive to Rust compiler diagnostic formatting. In
+practice, drift is usually caused by `rustc` version changes rather than by the
+feature change itself.
+
+When a trybuild test fails only because the expected and actual diagnostics have
+drifted, refresh the fixtures with:
+
+```bash
+TRYBUILD=overwrite cargo test -p genja-core --test derive_compile
+```
+
+Do not hand-edit `.stderr` fixtures unless you are making a small targeted
+correction. Prefer regenerating them from compiler output.
+
+Refresh trybuild snapshots only when:
+
+- macro diagnostics intentionally changed
+- the Rust toolchain changed and the emitted diagnostics legitimately drifted
+
+When adding new compile-fail fixtures, minimize unrelated warnings in the test
+case where possible so snapshot files are less brittle across toolchain
+updates.
+
 ## Python Checks
 
 The Python bindings live in `genja-core-python`. Run commands from that
@@ -108,6 +137,16 @@ Run the Rust tests that exercise the PyO3 crate:
 ```bash
 pdm run test-rust
 ```
+
+Use `pdm run test-rust` instead of invoking `cargo test -p genja-core-python`
+directly. The wrapper runs Cargo through the project Python environment, sets
+the correct `PYO3_PYTHON` interpreter, and ensures the PyO3-backed tests can
+access the installed Python packages.
+
+Avoid launching multiple `genja-core-python` Rust-backed test commands
+concurrently from separate processes. Each run is already single-threaded
+internally, and concurrent invocations may hang or fail to return output
+reliably in this workspace.
 
 Run type checks for the Python examples and tests:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,7 +17,7 @@ development environment needs:
 
 ## Tool Versions
 
-The workspace pins Rust and Cargo to 1.85.0 in `rust-toolchain.toml`. Use that
+The workspace pins Rust and Cargo to 1.88.0 in `rust-toolchain.toml`. Use that
 toolchain locally so compiler diagnostics, formatting, and trybuild snapshots
 match CI.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -127,6 +127,21 @@ When debugging PyO3 test failures, the project also provides:
 pdm run test-rust-debug
 ```
 
+## Changelog And Compatibility
+
+This repository uses a single top-level `CHANGELOG.md`.
+This repository follows Keep a Changelog style for `CHANGELOG.md`.
+
+- Add user-visible changes under `Unreleased`.
+- Use release-note headings such as:
+  - `Added`
+  - `Changed`
+  - `Fixed`
+  - `Removed`
+- Mark breaking entries inline with `**Breaking:**` and include migration guidance in the same bullet.
+- Update the changelog during the branch, not only at merge time.
+- For linked work items, use `Refs: #<issue>` when an issue exists.
+
 ## Documentation
 
 Documentation pages live in `docs/` and the navigation is configured in

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -54,6 +54,15 @@ Genja does not infer task mutability or idempotency when applying retries; the
 decision is driven entirely by configured policy and the task's returned
 failure result.
 
+Precedence for retry settings is:
+
+1. task-level retry metadata such as `allow_retries` and `max_task_attempts`
+2. runner-level retry defaults
+3. built-in fallback defaults
+
+See [Tasks](tasks.md) for Rust `#[genja_task(...)]` and Python `@task(...)`
+examples showing how to set task-level retry overrides.
+
 ## Threaded Runner
 
 The `threaded` runner executes a task across multiple hosts concurrently. It is

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -26,6 +26,8 @@ runner:
   worker_count: 10
   max_task_depth: 10
   max_connection_attempts: 3
+  allow_retries: false
+  max_task_attempts: 1
 ```
 
 Runner settings:
@@ -35,12 +37,17 @@ Runner settings:
 - `worker_count`: optional concurrency limit for runners that support it.
 - `max_task_depth`: maximum nested task depth. Defaults to `10`.
 - `max_connection_attempts`: maximum connection attempts. Defaults to `3`.
+- `allow_retries`: whether task retries are allowed by default. Defaults to `false`.
+- `max_task_attempts`: total number of task attempts allowed by default. Defaults to `1`.
 
 `max_connection_attempts` is part of the shared runner configuration. The
 built-in runners pass the task connection resolver into task execution; the
 connection layer is responsible for interpreting connection retry behavior.
 Custom runners should pass the resolver through when they delegate to task
 execution helpers.
+
+`allow_retries` and `max_task_attempts` define default retry policy for task
+execution. Tasks may override these defaults through task metadata.
 
 ## Threaded Runner
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -48,6 +48,8 @@ execution helpers.
 
 `allow_retries` and `max_task_attempts` define default retry policy for task
 execution. Tasks may override these defaults through task metadata.
+Retries are only attempted when the effective policy allows them and the task
+returns a failed host result marked as retryable.
 
 ## Threaded Runner
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -50,6 +50,9 @@ execution helpers.
 execution. Tasks may override these defaults through task metadata.
 Retries are only attempted when the effective policy allows them and the task
 returns a failed host result marked as retryable.
+Genja does not infer task mutability or idempotency when applying retries; the
+decision is driven entirely by configured policy and the task's returned
+failure result.
 
 ## Threaded Runner
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -66,6 +66,8 @@ runner:
   worker_count: 10
   max_task_depth: 10
   max_connection_attempts: 3
+  allow_retries: false
+  max_task_attempts: 1
 
 logging:
   enabled: true
@@ -229,6 +231,8 @@ runner:
 | `worker_count` | number or null | `null` | none |
 | `max_task_depth` | number | `10` | none |
 | `max_connection_attempts` | number | `3` | none |
+| `allow_retries` | boolean | `false` | none |
+| `max_task_attempts` | number | `1` | none |
 
 Common `plugin` values are `threaded` and `serial`.
 
@@ -243,6 +247,10 @@ use this setting.
 
 `max_connection_attempts` is part of shared runner configuration. Connection
 plugins or connection layers are responsible for interpreting retry behavior.
+
+`allow_retries` controls whether retries are allowed by default for task
+execution. `max_task_attempts` controls the default total attempt count for a
+task. Tasks may override either setting through task metadata.
 
 See [Runners](runners.md) for execution behavior and ordering details.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -250,7 +250,8 @@ plugins or connection layers are responsible for interpreting retry behavior.
 
 `allow_retries` controls whether retries are allowed by default for task
 execution. `max_task_attempts` controls the default total attempt count for a
-task. Tasks may override either setting through task metadata.
+task. Tasks may override either setting through task metadata. Retries are only
+attempted for failures explicitly marked as retryable.
 
 See [Runners](runners.md) for execution behavior and ordering details.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -252,7 +252,7 @@ Tasks return one result per host.
             .with_kind(TaskFailureKind::Connection),
     );
 
-    let skipped = HostTaskResult::Skipped(
+    let skipped = HostTaskResult::skipped_with_detail(
         TaskSkip::new()
             .with_reason("unsupported_platform")
             .with_message("host platform is not supported"),
@@ -292,6 +292,18 @@ kind, retryability, details, warnings, and messages. Skip results include a
 machine-readable reason and human-readable message. Per-host timing and retry
 data are reported on `HostTaskResult.execution_metadata`, not inside success or
 failure payloads.
+
+For Rust consumers, a good pattern is:
+
+```rust
+if let Some(failure) = host_result.failure() {
+    println!("failed: {}", failure.message());
+}
+
+if let Some(duration) = host_result.execution_metadata().duration_display() {
+    println!("duration: {duration}");
+}
+```
 
 Prefer returning an explicit failure or skip result when the task can classify
 the outcome. Reserve raised errors for unexpected internal errors that should be

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -289,7 +289,9 @@ Tasks return one result per host.
 Success results can include result payloads, change status, diffs, summaries,
 warnings, messages, and metadata. Failure results include a message, failure
 kind, retryability, details, warnings, and messages. Skip results include a
-machine-readable reason and human-readable message.
+machine-readable reason and human-readable message. Per-host timing and retry
+data are reported on `HostTaskResult.execution_metadata`, not inside success or
+failure payloads.
 
 Prefer returning an explicit failure or skip result when the task can classify
 the outcome. Reserve raised errors for unexpected internal errors that should be

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -143,6 +143,8 @@ The common macro options are:
 - `name`: task name shown in results and task trees
 - `connection_plugin_name`: connection plugin to open before task execution
 - `processors`: processor plugin names to run around task execution
+- `allow_retries`: optional task-level override for whether retries are allowed
+- `max_task_attempts`: optional task-level override for total task attempts
 
 Define exactly one task entrypoint in the macro `impl` block:
 
@@ -152,6 +154,89 @@ Define exactly one task entrypoint in the macro `impl` block:
 The macro can also read optional helper methods from the same `impl` block, such
 as `options(...)` and `sub_tasks(...)`. Use those helpers when a task needs
 dynamic JSON options or child tasks in a task tree.
+
+### Rust Retry Overrides
+
+Use task metadata when a Rust task should opt into retries or override the
+runner defaults for retry count:
+
+```rust
+use genja::genja_core::inventory::Host;
+use genja::genja_core::task::{
+    HostTaskResult, TaskError, TaskFailure, TaskFailureKind, TaskRuntimeContext,
+};
+use genja::genja_task;
+
+struct RetryableBackup;
+
+#[genja_task(
+    name = "retryable_backup",
+    connection_plugin_name = "ssh",
+    allow_retries = true,
+    max_task_attempts = 3
+)]
+impl RetryableBackup {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, TaskError> {
+        Ok(HostTaskResult::failed(
+            TaskFailure::new(std::io::Error::other("temporary rate limit"))
+                .with_kind(TaskFailureKind::External)
+                .with_retryable(true),
+        ))
+    }
+}
+```
+
+These values override runner defaults for that task only. Retries still happen
+only when the returned failure is explicitly marked `retryable`.
+
+## Python Task Decorator
+
+Python tasks use the `@task(...)` decorator for static task metadata.
+
+Common decorator options:
+
+- `name`: task name shown in results and task trees
+- `connection_plugin_name`: connection plugin to open before task execution
+- `processors`: processor plugin names to run around task execution
+- `sub_tasks`: child tasks to execute beneath the current task
+- `allow_retries`: optional task-level override for whether retries are allowed
+- `max_task_attempts`: optional task-level override for total task attempts
+
+### Python Retry Overrides
+
+Use decorator fields when a Python task should opt into retries or override the
+runner defaults for retry count:
+
+```python
+from genja.task import Host, TaskFailureResult, TaskInfo, TaskRuntimeContext, task
+
+
+@task(
+    name="retryable_backup",
+    connection_plugin_name="ssh",
+    allow_retries=True,
+    max_task_attempts=3,
+)
+class RetryableBackup:
+    def start(
+        self,
+        task: TaskInfo,
+        host: Host,
+        context: TaskRuntimeContext,
+    ) -> TaskFailureResult:
+        return TaskFailureResult(
+            message=f"temporary rate limit on {host.hostname}",
+            kind="external",
+            retryable=True,
+        )
+```
+
+These values override runner defaults for that task only. Retries still happen
+only when the returned failure result is explicitly marked `retryable`.
 
 ## Task Inputs
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -295,6 +295,10 @@ Prefer returning an explicit failure or skip result when the task can classify
 the outcome. Reserve raised errors for unexpected internal errors that should be
 treated as task execution failures by the runtime.
 
+When task retries are enabled by runner settings or task metadata, Genja only
+retries failures explicitly marked as retryable. Return a failed host result
+with `retryable=true` when the failure is transient and safe to retry.
+
 ## Failure Kinds
 
 Use failure kinds to make task failures easier to classify:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -312,6 +312,9 @@ treated as task execution failures by the runtime.
 When task retries are enabled by runner settings or task metadata, Genja only
 retries failures explicitly marked as retryable. Return a failed host result
 with `retryable=true` when the failure is transient and safe to retry.
+Genja does not infer whether a task is mutable, safe to repeat, or idempotent;
+retry behavior is always controlled by explicit policy plus the returned
+failure classification.
 
 ## Failure Kinds
 

--- a/genja-core-derive/src/lib.rs
+++ b/genja-core-derive/src/lib.rs
@@ -64,7 +64,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
     DeriveInput, Expr, ExprArray, ExprLit, FnArg, GenericArgument, ImplItem, ItemImpl, Lit, LitStr,
-    PathArguments, ReturnType, Token, Type, TypePath,
+    LitBool, LitInt, PathArguments, ReturnType, Token, Type, TypePath,
     parse::{Parse, ParseStream},
     parse_macro_input,
 };
@@ -161,6 +161,8 @@ struct GenjaTaskArgs {
     name: Option<LitStr>,
     connection_plugin_name: Option<LitStr>,
     processors: Vec<LitStr>,
+    allow_retries: Option<LitBool>,
+    max_task_attempts: Option<LitInt>,
 }
 
 impl Parse for GenjaTaskArgs {
@@ -194,10 +196,25 @@ impl Parse for GenjaTaskArgs {
                     let array: ExprArray = input.parse()?;
                     args.processors = parse_processor_exprs(&array)?;
                 }
+                "allow_retries" => {
+                    if args.allow_retries.is_some() {
+                        return Err(syn::Error::new_spanned(key, "duplicate `allow_retries`"));
+                    }
+                    args.allow_retries = Some(input.parse()?);
+                }
+                "max_task_attempts" => {
+                    if args.max_task_attempts.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "duplicate `max_task_attempts`",
+                        ));
+                    }
+                    args.max_task_attempts = Some(input.parse()?);
+                }
                 _ => {
                     return Err(syn::Error::new_spanned(
                         key,
-                        "unsupported key; expected `name`, `connection_plugin_name`, or `processors`",
+                        "unsupported key; expected `name`, `connection_plugin_name`, `processors`, `allow_retries`, or `max_task_attempts`",
                     ));
                 }
             }
@@ -284,6 +301,8 @@ fn expand_genja_task(
     let name = args.name.expect("validated above");
     let connection_plugin_name = args.connection_plugin_name;
     let processors = args.processors;
+    let allow_retries = args.allow_retries;
+    let max_task_attempts = args.max_task_attempts;
 
     let connection_impl = match connection_plugin_name {
         Some(plugin_name) => quote! { Some(#plugin_name) },
@@ -318,6 +337,24 @@ fn expand_genja_task(
                 vec![#(#processors),*]
             }
         }
+    };
+
+    let allow_retries_impl = match allow_retries {
+        Some(allow_retries) => quote! {
+            fn allow_retries(&self) -> Option<bool> {
+                Some(#allow_retries)
+            }
+        },
+        None => quote! {},
+    };
+
+    let max_task_attempts_impl = match max_task_attempts {
+        Some(max_task_attempts) => quote! {
+            fn max_task_attempts(&self) -> Option<usize> {
+                Some(#max_task_attempts)
+            }
+        },
+        None => quote! {},
     };
 
     let task_impl = if has_start {
@@ -375,6 +412,10 @@ fn expand_genja_task(
             #options_impl
 
             #processor_names_impl
+
+            #allow_retries_impl
+
+            #max_task_attempts_impl
         }
 
         #task_impl

--- a/genja-core-derive/src/lib.rs
+++ b/genja-core-derive/src/lib.rs
@@ -63,8 +63,8 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    DeriveInput, Expr, ExprArray, ExprLit, FnArg, GenericArgument, ImplItem, ItemImpl, Lit, LitStr,
-    LitBool, LitInt, PathArguments, ReturnType, Token, Type, TypePath,
+    DeriveInput, Expr, ExprArray, ExprLit, FnArg, GenericArgument, ImplItem, ItemImpl, Lit,
+    LitBool, LitInt, LitStr, PathArguments, ReturnType, Token, Type, TypePath,
     parse::{Parse, ParseStream},
     parse_macro_input,
 };

--- a/genja-core-python/README.md
+++ b/genja-core-python/README.md
@@ -69,6 +69,9 @@ all_results = genja.run_tasks(tasks)
 print([result.task_name for result in all_results])
 ```
 
+`results.to_dict()` returns per-host task results with an `outcome` payload and
+separate `execution_metadata` for host timing and retry attempt information.
+
 `TaskRuntimeContext` exposes the resolved connection through
 `context.connection()` and `context.has_connection()`. Execution depth remains
 internal to the runtime.

--- a/genja-core-python/python/genja/task.py
+++ b/genja-core-python/python/genja/task.py
@@ -108,6 +108,14 @@ Task metadata comes from ``@task(...)``:
 - ``allow_retries``: optional explicit retry authorization override
 - ``max_task_attempts``: optional explicit total-attempt override
 - ``options``: optional JSON-serializable task options payload
+
+Retry metadata only controls policy. A task is retried only when both of these
+conditions are true:
+
+- the effective retry policy allows another attempt
+- the task returns ``TaskFailureResult(..., retryable=True)``
+
+Genja does not infer whether a task is safe to repeat, mutable, or idempotent.
 """
 
 from __future__ import annotations
@@ -474,9 +482,12 @@ def task(
             non-empty strings. If None, no processors will be applied.
         allow_retries (bool | None): Optional explicit override for whether
             retries are allowed for this task. If None, runtime defaults apply.
+            This setting does not force retries by itself; the task must still
+            return ``TaskFailureResult(..., retryable=True)``.
         max_task_attempts (int | None): Optional explicit override for the
             total number of attempts allowed for this task. Must be positive
-            when provided.
+            when provided. This bounds total attempts but does not override the
+            requirement that failures be marked retryable.
         options (Any | None): Optional JSON-serializable payload containing
             task-specific configuration options. Can be any JSON-compatible
             data structure. If None, no options are provided to the task.

--- a/genja-core-python/python/genja/task.py
+++ b/genja-core-python/python/genja/task.py
@@ -105,6 +105,8 @@ Task metadata comes from ``@task(...)``:
 - ``connection_plugin_name``: optional; when provided it must be non-empty
 - ``sub_tasks``: optional list of decorated task classes
 - ``processors``: optional list of processor plugin names
+- ``allow_retries``: optional explicit retry authorization override
+- ``max_task_attempts``: optional explicit total-attempt override
 - ``options``: optional JSON-serializable task options payload
 """
 
@@ -220,6 +222,11 @@ class TaskInfo(_GenjaModel):
             that can observe or modify task execution before and after task or
             host-level result handling. Defaults to an empty list if no
             processors are specified.
+        allow_retries (bool | None): Optional explicit override for whether
+            retries are allowed for this task. If None, runtime defaults apply.
+        max_task_attempts (int | None): Optional explicit override for the
+            total number of attempts allowed for this task. If None, runtime
+            defaults apply.
         options (Any | None): Optional JSON-serializable payload containing
             task-specific configuration options. Can be any JSON-compatible
             data structure or None if no options are provided.
@@ -238,6 +245,14 @@ class TaskInfo(_GenjaModel):
     processors: list[str] = Field(
         default_factory=list,
         description="Processor plugin names applied to this task.",
+    )
+    allow_retries: bool | None = Field(
+        default=None,
+        description="Optional explicit retry authorization override.",
+    )
+    max_task_attempts: int | None = Field(
+        default=None,
+        description="Optional explicit total-attempt override.",
     )
     options: Any | None = Field(
         default=None,
@@ -431,6 +446,8 @@ def task(
     connection_plugin_name: str | None = None,
     sub_tasks: list[type[GenjaTaskProtocol]] | None = None,
     processors: list[str] | None = None,
+    allow_retries: bool | None = None,
+    max_task_attempts: int | None = None,
     options: Any | None = None,
 ):
     """Attach Genja task metadata to a Python task class.
@@ -455,6 +472,11 @@ def task(
         processors (list[str] | None): Optional list of processor plugin names
             to apply to this task's execution. If provided, must be a list of
             non-empty strings. If None, no processors will be applied.
+        allow_retries (bool | None): Optional explicit override for whether
+            retries are allowed for this task. If None, runtime defaults apply.
+        max_task_attempts (int | None): Optional explicit override for the
+            total number of attempts allowed for this task. Must be positive
+            when provided.
         options (Any | None): Optional JSON-serializable payload containing
             task-specific configuration options. Can be any JSON-compatible
             data structure. If None, no options are provided to the task.
@@ -470,7 +492,9 @@ def task(
             if the name is not a non-empty string, if connection_plugin_name is
             not a non-empty string or None, if sub_tasks is not a list of
             @task-decorated classes or None, if processors is not a list of
-            non-empty strings or None, or if options is not JSON-serializable.
+            non-empty strings or None, if allow_retries is not bool or None,
+            if max_task_attempts is not a positive integer or None, or if
+            options is not JSON-serializable.
     """
 
     def wrap(cls: _TaskClassT) -> _TaskClassT:
@@ -518,6 +542,16 @@ def task(
                     raise TypeError(
                         f"@task-decorated class '{cls.__name__}' processors must contain non-empty strings"
                     )
+        if allow_retries is not None and not isinstance(allow_retries, bool):
+            raise TypeError(
+                f"@task-decorated class '{cls.__name__}' allow_retries must be bool or None"
+            )
+        if max_task_attempts is not None and (
+            not isinstance(max_task_attempts, int) or max_task_attempts < 1
+        ):
+            raise TypeError(
+                f"@task-decorated class '{cls.__name__}' max_task_attempts must be a positive integer or None"
+            )
         _ensure_json_serializable(options, "options")
 
         task_cls = cast(type[GenjaTaskProtocol], cls)
@@ -525,6 +559,8 @@ def task(
             "name": name,
             "connection_plugin_name": connection_plugin_name,
             "processors": list(processors or []),
+            "allow_retries": allow_retries,
+            "max_task_attempts": max_task_attempts,
             "options": options,
             "sub_tasks": validated_sub_tasks,
         }

--- a/genja-core-python/python/tests/fixtures/processor_plugins.py
+++ b/genja-core-python/python/tests/fixtures/processor_plugins.py
@@ -21,8 +21,12 @@ class AuditProcessor:
     def on_instance_finish(self, context, result):
         self.events.append(("instance_finish", context.task_name, context.hostname))
         data = result.to_dict()
-        data["metadata"] = {
-            **(data.get("metadata") or {}),
+        outcome = data.get("outcome", {})
+        passed = outcome.get("Passed")
+        if passed is None:
+            return data
+        passed["metadata"] = {
+            **(passed.get("metadata") or {}),
             "processor": "audit",
             "hostname": context.hostname,
         }

--- a/genja-core-python/python/tests/test_async_tasks.py
+++ b/genja-core-python/python/tests/test_async_tasks.py
@@ -78,7 +78,10 @@ def test_runtime_run_task_async_executes_async_task():
     assert results.failed_hosts == []
 
     data = results.to_dict()
-    assert "async backup completed" in data["hosts"]["router1"]["summary"]
+    assert (
+        "async backup completed"
+        in data["hosts"]["router1"]["outcome"]["Passed"]["summary"]
+    )
 
 
 def test_runtime_run_task_async_handles_failures():
@@ -96,7 +99,7 @@ def test_runtime_run_task_async_handles_failures():
     assert results.failed_hosts == ["router1"]
 
     data = results.to_dict()
-    assert "async task failed" in data["hosts"]["router1"]["message"]
+    assert "async task failed" in data["hosts"]["router1"]["outcome"]["Failed"]["message"]
 
 
 def test_runtime_run_task_async_with_connection():
@@ -227,7 +230,7 @@ def test_runtime_run_task_async_handles_exception_in_task():
 
     assert results.failed_hosts == ["router1"]
     data = results.to_dict()
-    assert "something went wrong" in data["hosts"]["router1"]["message"]
+    assert "something went wrong" in data["hosts"]["router1"]["outcome"]["Failed"]["message"]
 
 
 def test_runtime_run_task_async_with_timeout():

--- a/genja-core-python/python/tests/test_async_tasks.py
+++ b/genja-core-python/python/tests/test_async_tasks.py
@@ -99,7 +99,9 @@ def test_runtime_run_task_async_handles_failures():
     assert results.failed_hosts == ["router1"]
 
     data = results.to_dict()
-    assert "async task failed" in data["hosts"]["router1"]["outcome"]["Failed"]["message"]
+    assert (
+        "async task failed" in data["hosts"]["router1"]["outcome"]["Failed"]["message"]
+    )
 
 
 def test_runtime_run_task_async_with_connection():
@@ -230,7 +232,10 @@ def test_runtime_run_task_async_handles_exception_in_task():
 
     assert results.failed_hosts == ["router1"]
     data = results.to_dict()
-    assert "something went wrong" in data["hosts"]["router1"]["outcome"]["Failed"]["message"]
+    assert (
+        "something went wrong"
+        in data["hosts"]["router1"]["outcome"]["Failed"]["message"]
+    )
 
 
 def test_runtime_run_task_async_with_timeout():

--- a/genja-core-python/python/tests/test_processors.py
+++ b/genja-core-python/python/tests/test_processors.py
@@ -28,8 +28,7 @@ def test_plugin_manager_register_plugin_executes_python_processor():
     data = results.to_dict()
 
     assert data["summary"] == "processed by audit"
-    assert data["hosts"]["router1"]["status"] == "passed"
-    assert data["hosts"]["router1"]["metadata"] == {
+    assert data["hosts"]["router1"]["outcome"]["Passed"]["metadata"] == {
         "platform": "ios",
         "processor": "audit",
         "hostname": "router1",
@@ -82,5 +81,7 @@ def test_plugin_manager_loads_python_processors_from_pyproject(tmp_path):
         sys.modules.pop("processor_plugins", None)
 
     data = results.to_dict()
-    assert data["hosts"]["router1"]["status"] == "passed"
-    assert data["hosts"]["router1"]["metadata"]["loaded_from"] == "pyproject"
+    assert (
+        data["hosts"]["router1"]["outcome"]["Passed"]["metadata"]["loaded_from"]
+        == "pyproject"
+    )

--- a/genja-core-python/python/tests/test_processors.py
+++ b/genja-core-python/python/tests/test_processors.py
@@ -51,7 +51,7 @@ def test_plugin_manager_loads_python_processors_from_pyproject(tmp_path):
             class AuditProcessor(BaseAuditProcessor):
                 def on_instance_finish(self, context, result):
                     data = super().on_instance_finish(context, result)
-                    data["metadata"]["loaded_from"] = "pyproject"
+                    data["outcome"]["Passed"]["metadata"]["loaded_from"] = "pyproject"
                     return data
             """
         )

--- a/genja-core-python/python/tests/test_runtime.py
+++ b/genja-core-python/python/tests/test_runtime.py
@@ -203,12 +203,9 @@ def test_genja_runtime_runs_ordered_task_list_with_nested_subtasks():
 
     parent_data = results[1].to_dict(raw=True)
     assert "runtime_child" in parent_data["sub_tasks"]
-    assert (
-        parent_data["sub_tasks"]["runtime_child"]["hosts"]["router1"]["outcome"]["Passed"][
-            "metadata"
-        ]
-        == {"has_connection": False}
-    )
+    assert parent_data["sub_tasks"]["runtime_child"]["hosts"]["router1"]["outcome"][
+        "Passed"
+    ]["metadata"] == {"has_connection": False}
 
 
 def test_genja_runtime_run_tasks_rejects_plain_task_iterable():

--- a/genja-core-python/python/tests/test_runtime.py
+++ b/genja-core-python/python/tests/test_runtime.py
@@ -105,10 +105,14 @@ def test_genja_runtime_runs_python_task_definition():
     assert results.skipped_hosts == []
     assert summary == {"passed": 2, "failed": 0, "skipped": 0, "total": 2}
     assert data["task_name"] == "runtime_backup"
-    assert data["hosts"]["router1"]["status"] == "passed"
-    assert data["hosts"]["router1"]["summary"] == "runtime handled 10.0.0.1"
-    assert data["hosts"]["router2"]["status"] == "passed"
-    assert data["hosts"]["router2"]["metadata"]["platform"] == "ios"
+    assert (
+        data["hosts"]["router1"]["outcome"]["Passed"]["summary"]
+        == "runtime handled 10.0.0.1"
+    )
+    assert (
+        data["hosts"]["router2"]["outcome"]["Passed"]["metadata"]["platform"]
+        == "ios"
+    )
 
 
 def test_genja_runtime_run_task_async_awaits_async_python_task():
@@ -224,12 +228,14 @@ def test_task_results_to_dict_normalizes_non_raw_and_preserves_raw_shape():
     normalized = results.to_dict()
     raw = results.to_dict(raw=True)
 
-    assert normalized["hosts"]["router1"]["status"] == "passed"
-    assert normalized["hosts"]["router1"]["summary"] == "runtime handled 10.0.0.1"
-    assert "Passed" not in normalized["hosts"]["router1"]
-
-    assert raw["hosts"]["router1"]["Passed"]["summary"] == "runtime handled 10.0.0.1"
-    assert "status" not in raw["hosts"]["router1"]
+    assert (
+        normalized["hosts"]["router1"]["outcome"]["Passed"]["summary"]
+        == "runtime handled 10.0.0.1"
+    )
+    assert (
+        raw["hosts"]["router1"]["outcome"]["Passed"]["summary"]
+        == "runtime handled 10.0.0.1"
+    )
 
 
 def test_genja_inventory_accessors_expose_host_payloads():
@@ -366,8 +372,7 @@ def test_genja_runtime_passes_python_connection_into_runtime_context():
     results = runtime.run_task(RuntimeConnectionTask)
     data = results.to_dict()
 
-    assert data["hosts"]["router1"]["status"] == "passed"
-    assert data["hosts"]["router1"]["metadata"] == {
+    assert data["hosts"]["router1"]["outcome"]["Passed"]["metadata"] == {
         "connection_alive": True,
         "connection_hostname": "router1",
         "opened_with": {

--- a/genja-core-python/python/tests/test_runtime.py
+++ b/genja-core-python/python/tests/test_runtime.py
@@ -129,7 +129,10 @@ def test_genja_runtime_run_task_async_awaits_async_python_task():
     assert results.failed_hosts == []
     assert results.skipped_hosts == []
     data = results.to_dict()
-    assert data["hosts"]["router1"]["summary"] == "async runtime handled 10.0.0.1"
+    assert (
+        data["hosts"]["router1"]["outcome"]["Passed"]["summary"]
+        == "async runtime handled 10.0.0.1"
+    )
 
 
 def test_genja_runtime_run_tasks_async_preserves_order():
@@ -200,9 +203,12 @@ def test_genja_runtime_runs_ordered_task_list_with_nested_subtasks():
 
     parent_data = results[1].to_dict(raw=True)
     assert "runtime_child" in parent_data["sub_tasks"]
-    assert parent_data["sub_tasks"]["runtime_child"]["hosts"]["router1"]["Passed"][
-        "metadata"
-    ] == {"has_connection": False}
+    assert (
+        parent_data["sub_tasks"]["runtime_child"]["hosts"]["router1"]["outcome"]["Passed"][
+            "metadata"
+        ]
+        == {"has_connection": False}
+    )
 
 
 def test_genja_runtime_run_tasks_rejects_plain_task_iterable():
@@ -344,10 +350,12 @@ def test_genja_runtime_hides_depth_from_python_task_context():
     results = runtime.run_task(RuntimeParentTask, max_depth=1)
     data = results.to_dict(raw=True)
 
-    assert data["hosts"]["router1"]["Passed"]["metadata"] == {"has_connection": False}
+    assert data["hosts"]["router1"]["outcome"]["Passed"]["metadata"] == {
+        "has_connection": False
+    }
 
     child_results = data["sub_tasks"]["runtime_child"]
-    assert child_results["hosts"]["router1"]["Passed"]["metadata"] == {
+    assert child_results["hosts"]["router1"]["outcome"]["Passed"]["metadata"] == {
         "has_connection": False
     }
 

--- a/genja-core-python/python/tests/test_runtime.py
+++ b/genja-core-python/python/tests/test_runtime.py
@@ -110,8 +110,7 @@ def test_genja_runtime_runs_python_task_definition():
         == "runtime handled 10.0.0.1"
     )
     assert (
-        data["hosts"]["router2"]["outcome"]["Passed"]["metadata"]["platform"]
-        == "ios"
+        data["hosts"]["router2"]["outcome"]["Passed"]["metadata"]["platform"] == "ios"
     )
 
 

--- a/genja-core-python/python/tests/test_task_definition.py
+++ b/genja-core-python/python/tests/test_task_definition.py
@@ -115,7 +115,9 @@ def test_task_definition_run_on_host_executes_python_body():
     data = result.to_dict()
 
     assert result.passed_hosts == ["router1"]
-    assert data["hosts"]["router1"]["outcome"]["Passed"]["summary"] == "backed up router1"
+    assert (
+        data["hosts"]["router1"]["outcome"]["Passed"]["summary"] == "backed up router1"
+    )
     assert (
         data["hosts"]["router1"]["outcome"]["Passed"]["metadata"]["sub_task_name"]
         == "verify_backup_plain"

--- a/genja-core-python/python/tests/test_task_definition.py
+++ b/genja-core-python/python/tests/test_task_definition.py
@@ -115,12 +115,15 @@ def test_task_definition_run_on_host_executes_python_body():
     data = result.to_dict()
 
     assert result.passed_hosts == ["router1"]
-    assert data["hosts"]["router1"]["status"] == "passed"
-    assert data["hosts"]["router1"]["summary"] == "backed up router1"
+    assert data["hosts"]["router1"]["outcome"]["Passed"]["summary"] == "backed up router1"
     assert (
-        data["hosts"]["router1"]["metadata"]["sub_task_name"] == "verify_backup_plain"
+        data["hosts"]["router1"]["outcome"]["Passed"]["metadata"]["sub_task_name"]
+        == "verify_backup_plain"
     )
-    assert data["hosts"]["router1"]["metadata"]["backup_path"] == "/tmp/configs"
+    assert (
+        data["hosts"]["router1"]["outcome"]["Passed"]["metadata"]["backup_path"]
+        == "/tmp/configs"
+    )
 
 
 def test_task_definition_from_python_class_requires_decorator_metadata():

--- a/genja-core-python/python/tests/test_task_results.py
+++ b/genja-core-python/python/tests/test_task_results.py
@@ -37,7 +37,7 @@ def test_host_task_result_from_python_success_result_round_trips():
     assert data["outcome"]["Passed"]["changed"] is True
     assert data["outcome"]["Passed"]["summary"] == "backup complete"
     assert data["outcome"]["Passed"]["warnings"] == ["using fallback path"]
-    assert data["outcome"]["Passed"]["messages"][0]["level"] == "info"
+    assert data["outcome"]["Passed"]["messages"][0]["level"] == "Info"
     assert data["outcome"]["Passed"]["messages"][0]["text"] == "backup complete"
     assert data["outcome"]["Passed"]["messages"][0]["code"] == "BACKUP_DONE"
     assert data["outcome"]["Passed"]["metadata"]["backup_file"] == "/tmp/router1.cfg"
@@ -58,7 +58,7 @@ def test_host_task_result_from_python_failure_result_round_trips():
     data = host_result.to_dict()
 
     assert host_result.status == "failed"
-    assert data["outcome"]["Failed"]["kind"] == "timeout"
+    assert data["outcome"]["Failed"]["kind"] == "Timeout"
     assert data["outcome"]["Failed"]["message"] == "connection timeout"
     assert data["outcome"]["Failed"]["retryable"] is True
     assert data["outcome"]["Failed"]["details"]["timeout_seconds"] == 30

--- a/genja-core-python/python/tests/test_task_results.py
+++ b/genja-core-python/python/tests/test_task_results.py
@@ -33,14 +33,15 @@ def test_host_task_result_from_python_success_result_round_trips():
     data = host_result.to_dict()
 
     assert host_result.status == "passed"
-    assert data["status"] == "passed"
-    assert data["changed"] is True
-    assert data["summary"] == "backup complete"
-    assert data["warnings"] == ["using fallback path"]
-    assert data["messages"][0]["level"] == "info"
-    assert data["messages"][0]["text"] == "backup complete"
-    assert data["messages"][0]["code"] == "BACKUP_DONE"
-    assert data["metadata"]["backup_file"] == "/tmp/router1.cfg"
+    assert "Passed" in data["outcome"]
+    assert data["outcome"]["Passed"]["changed"] is True
+    assert data["outcome"]["Passed"]["summary"] == "backup complete"
+    assert data["outcome"]["Passed"]["warnings"] == ["using fallback path"]
+    assert data["outcome"]["Passed"]["messages"][0]["level"] == "info"
+    assert data["outcome"]["Passed"]["messages"][0]["text"] == "backup complete"
+    assert data["outcome"]["Passed"]["messages"][0]["code"] == "BACKUP_DONE"
+    assert data["outcome"]["Passed"]["metadata"]["backup_file"] == "/tmp/router1.cfg"
+    assert data["execution_metadata"]["attempts"] == 1
 
 
 def test_host_task_result_from_python_failure_result_round_trips():
@@ -57,10 +58,10 @@ def test_host_task_result_from_python_failure_result_round_trips():
     data = host_result.to_dict()
 
     assert host_result.status == "failed"
-    assert data["kind"] == "timeout"
-    assert data["message"] == "connection timeout"
-    assert data["retryable"] is True
-    assert data["details"]["timeout_seconds"] == 30
+    assert data["outcome"]["Failed"]["kind"] == "timeout"
+    assert data["outcome"]["Failed"]["message"] == "connection timeout"
+    assert data["outcome"]["Failed"]["retryable"] is True
+    assert data["outcome"]["Failed"]["details"]["timeout_seconds"] == 30
 
 
 def test_task_success_result_rejects_non_json_serializable_metadata():
@@ -116,8 +117,8 @@ def test_host_task_result_from_python_skip_result_round_trips():
     data = host_result.to_dict()
 
     assert host_result.status == "skipped"
-    assert data["reason"] == "maintenance_mode"
-    assert data["message"] == "host is in maintenance mode"
+    assert data["outcome"]["Skipped"]["reason"] == "maintenance_mode"
+    assert data["outcome"]["Skipped"]["message"] == "host is in maintenance mode"
 
 
 def test_host_task_result_from_python_result_rejects_missing_status():

--- a/genja-core-python/src/settings.rs
+++ b/genja-core-python/src/settings.rs
@@ -148,13 +148,25 @@ impl PyRunnerConfig {
         self.inner.max_connection_attempts()
     }
 
+    #[getter]
+    pub(crate) fn allow_retries(&self) -> bool {
+        self.inner.allow_retries()
+    }
+
+    #[getter]
+    pub(crate) fn max_task_attempts(&self) -> usize {
+        self.inner.max_task_attempts()
+    }
+
     fn __repr__(&self) -> String {
         format!(
-            "RunnerConfig(plugin={:?}, worker_count={:?}, max_task_depth={}, max_connection_attempts={})",
+            "RunnerConfig(plugin={:?}, worker_count={:?}, max_task_depth={}, max_connection_attempts={}, allow_retries={}, max_task_attempts={})",
             self.plugin(),
             self.worker_count(),
             self.max_task_depth(),
-            self.max_connection_attempts()
+            self.max_connection_attempts(),
+            self.allow_retries(),
+            self.max_task_attempts()
         )
     }
 }

--- a/genja-core-python/src/task.rs
+++ b/genja-core-python/src/task.rs
@@ -6,7 +6,6 @@ use ::genja_core::task::{
     TaskResultsSummary, TaskRuntimeContext, TaskSkip, TaskSuccess, Tasks,
 };
 use async_trait::async_trait;
-use humantime::format_rfc3339;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyModule};
@@ -42,11 +41,7 @@ impl PyHostTaskResult {
 
     #[getter]
     fn status(&self) -> &'static str {
-        match self.inner {
-            HostTaskResult::Passed(_) => "passed",
-            HostTaskResult::Failed(_) => "failed",
-            HostTaskResult::Skipped(_) => "skipped",
-        }
+        self.inner.status()
     }
 
     fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
@@ -677,6 +672,10 @@ pub(crate) fn python_result_to_task_results(obj: Bound<'_, PyAny>) -> PyResult<T
 }
 
 fn host_task_result_from_payload(value: &Value) -> PyResult<HostTaskResult> {
+    if let Some(outcome) = value.get("outcome") {
+        return host_task_result_from_payload(outcome);
+    }
+
     let result_value = if let Some(passed) = value.get("Passed") {
         let mut tagged = passed.clone();
         tagged["status"] = Value::String("passed".to_string());
@@ -701,7 +700,9 @@ fn host_task_result_from_payload(value: &Value) -> PyResult<HostTaskResult> {
     match status {
         "passed" => Ok(HostTaskResult::passed(json_to_task_success(&result_value)?)),
         "failed" => Ok(HostTaskResult::failed(json_to_task_failure(&result_value)?)),
-        "skipped" => Ok(HostTaskResult::Skipped(json_to_task_skip(&result_value))),
+        "skipped" => Ok(HostTaskResult::skipped_with_detail(json_to_task_skip(
+            &result_value,
+        ))),
         other => Err(PyValueError::new_err(format!(
             "unsupported python task result status '{other}'"
         ))),
@@ -843,32 +844,7 @@ fn parse_failure_kind(kind: &str) -> PyResult<TaskFailureKind> {
 }
 
 fn host_task_result_to_json(result: &HostTaskResult) -> Value {
-    match result {
-        HostTaskResult::Passed(success) => json!({
-            "status": "passed",
-            "result": success.result(),
-            "changed": success.changed(),
-            "diff": success.diff(),
-            "summary": success.summary(),
-            "warnings": success.warnings(),
-            "messages": success.messages().iter().map(task_message_to_json).collect::<Vec<_>>(),
-            "metadata": success.metadata(),
-        }),
-        HostTaskResult::Failed(failure) => json!({
-            "status": "failed",
-            "kind": failure_kind_to_str(failure.kind()),
-            "message": failure.message(),
-            "retryable": failure.retryable(),
-            "details": failure.details(),
-            "warnings": failure.warnings(),
-            "messages": failure.messages().iter().map(task_message_to_json).collect::<Vec<_>>(),
-        }),
-        HostTaskResult::Skipped(skip) => json!({
-            "status": "skipped",
-            "reason": skip.reason(),
-            "message": skip.message(),
-        }),
-    }
+    serde_json::to_value(result).expect("host task result should serialize")
 }
 
 fn normalize_task_results_json(value: &Value) -> Value {
@@ -930,41 +906,6 @@ fn task_results_summary_to_json(summary: &TaskResultsSummary) -> Value {
         "duration": summary.duration_display(),
         "sub_tasks": Value::Object(sub_tasks),
     })
-}
-
-pub(crate) fn task_message_to_json(message: &TaskMessage) -> Value {
-    json!({
-        "level": message_level_to_str(message.level()),
-        "text": message.text(),
-        "code": message.code(),
-        "timestamp": message.timestamp().map(format_timestamp),
-    })
-}
-
-fn message_level_to_str(level: &MessageLevel) -> &'static str {
-    match level {
-        MessageLevel::Info => "info",
-        MessageLevel::Warning => "warning",
-        MessageLevel::Error => "error",
-        MessageLevel::Debug => "debug",
-    }
-}
-
-fn failure_kind_to_str(kind: &TaskFailureKind) -> &'static str {
-    match kind {
-        TaskFailureKind::Connection => "connection",
-        TaskFailureKind::Authentication => "authentication",
-        TaskFailureKind::Validation => "validation",
-        TaskFailureKind::Timeout => "timeout",
-        TaskFailureKind::Command => "command",
-        TaskFailureKind::Unsupported => "unsupported",
-        TaskFailureKind::Internal => "internal",
-        TaskFailureKind::External => "external",
-    }
-}
-
-fn format_timestamp(timestamp: SystemTime) -> String {
-    format_rfc3339(timestamp).to_string()
 }
 
 fn task_definition_to_json(task_definition: &TaskDefinition) -> Value {
@@ -1531,13 +1472,22 @@ mod tests {
                 .expect("success result should convert");
             let data = host_task_result_to_json(&host_result);
 
-            assert!(matches!(host_result, HostTaskResult::Passed(_)));
-            assert_eq!(data["status"], "passed");
-            assert_eq!(data["changed"], true);
-            assert_eq!(data["summary"], "backup complete");
-            assert_eq!(data["warnings"], json!(["using fallback path"]));
-            assert_eq!(data["messages"][0]["code"], "BACKUP_DONE");
-            assert_eq!(data["metadata"]["backup_file"], "/tmp/router1.cfg");
+            assert!(host_result.is_passed());
+            assert!(data["outcome"]["Passed"].is_object());
+            assert_eq!(data["outcome"]["Passed"]["changed"], true);
+            assert_eq!(data["outcome"]["Passed"]["summary"], "backup complete");
+            assert_eq!(
+                data["outcome"]["Passed"]["warnings"],
+                json!(["using fallback path"])
+            );
+            assert_eq!(
+                data["outcome"]["Passed"]["messages"][0]["code"],
+                "BACKUP_DONE"
+            );
+            assert_eq!(
+                data["outcome"]["Passed"]["metadata"]["backup_file"],
+                "/tmp/router1.cfg"
+            );
         });
     }
 
@@ -1742,10 +1692,9 @@ mod tests {
                 .host_result("router1")
                 .expect("router1 result should exist");
             assert!(host_result.is_passed());
-            let success = match host_result {
-                HostTaskResult::Passed(success) => success,
-                _ => unreachable!("host result should be passed"),
-            };
+            let success = host_result
+                .success()
+                .expect("host result should be passed");
             assert!(success.changed());
             assert_eq!(success.summary(), Some("async handled router1"));
             assert_eq!(success.metadata().unwrap()["has_connection"], json!(false));

--- a/genja-core-python/src/task.rs
+++ b/genja-core-python/src/task.rs
@@ -312,6 +312,16 @@ impl PyTaskDefinition {
             .collect()
     }
 
+    #[getter]
+    fn allow_retries(&self) -> Option<bool> {
+        self.inner.allow_retries()
+    }
+
+    #[getter]
+    fn max_task_attempts(&self) -> Option<usize> {
+        self.inner.max_task_attempts()
+    }
+
     fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         match self.spec.as_ref() {
             Some(spec) => json_value_to_py(py, &python_task_spec_to_json(spec)),
@@ -927,6 +937,8 @@ fn task_to_json(task: &dyn Task) -> Value {
         "name": task.name(),
         "connection_plugin_name": task.connection_plugin_name(),
         "processors": task.processor_names(),
+        "allow_retries": task.allow_retries(),
+        "max_task_attempts": task.max_task_attempts(),
         "options": task.options(),
         "sub_tasks": task.sub_tasks().into_iter().map(|sub_task| task_to_json(sub_task.as_ref())).collect::<Vec<_>>(),
     })

--- a/genja-core-python/src/task.rs
+++ b/genja-core-python/src/task.rs
@@ -59,6 +59,8 @@ struct PythonTaskSpec {
     name: String,
     connection_plugin_name: Option<String>,
     processor_names: Vec<String>,
+    allow_retries: Option<bool>,
+    max_task_attempts: Option<usize>,
     options: Option<Value>,
     py_task_class: Arc<Py<PyAny>>,
     execution_mode: PythonTaskExecutionMode,
@@ -94,6 +96,14 @@ impl TaskInfo for PythonBackedTask {
 
     fn options(&self) -> Option<&Value> {
         self.spec.options.as_ref()
+    }
+
+    fn allow_retries(&self) -> Option<bool> {
+        self.spec.allow_retries
+    }
+
+    fn max_task_attempts(&self) -> Option<usize> {
+        self.spec.max_task_attempts
     }
 }
 
@@ -1022,6 +1032,30 @@ fn extract_python_task_spec(py_task_class: Bound<'_, PyAny>) -> PyResult<PythonT
     } else {
         Vec::new()
     };
+    let allow_retries = if let Some(value) = info.get_item("allow_retries")? {
+        if value.is_none() {
+            None
+        } else {
+            Some(value.extract::<bool>()?)
+        }
+    } else {
+        None
+    };
+    let max_task_attempts = if let Some(value) = info.get_item("max_task_attempts")? {
+        if value.is_none() {
+            None
+        } else {
+            let max_task_attempts = value.extract::<usize>()?;
+            if max_task_attempts < 1 {
+                return Err(PyValueError::new_err(
+                    "python task metadata field 'max_task_attempts' must be at least 1",
+                ));
+            }
+            Some(max_task_attempts)
+        }
+    } else {
+        None
+    };
 
     let options = if let Some(options) = info.get_item("options")? {
         if options.is_none() {
@@ -1046,6 +1080,8 @@ fn extract_python_task_spec(py_task_class: Bound<'_, PyAny>) -> PyResult<PythonT
         name,
         connection_plugin_name,
         processor_names,
+        allow_retries,
+        max_task_attempts,
         options,
         py_task_class: Arc::new(py_task_class.unbind()),
         execution_mode,
@@ -1073,6 +1109,8 @@ fn python_task_spec_to_json(spec: &PythonTaskSpec) -> Value {
         "name": spec.name,
         "connection_plugin_name": spec.connection_plugin_name,
         "processors": spec.processor_names,
+        "allow_retries": spec.allow_retries,
+        "max_task_attempts": spec.max_task_attempts,
         "options": spec.options,
         "sub_tasks": spec.sub_tasks.iter().map(python_task_spec_to_json).collect::<Vec<_>>(),
     })
@@ -1091,6 +1129,14 @@ fn python_task_spec_to_py_dict<'py>(
         None => task.set_item("connection_plugin_name", py.None())?,
     }
     task.set_item("processors", &spec.processor_names)?;
+    match spec.allow_retries {
+        Some(allow_retries) => task.set_item("allow_retries", allow_retries)?,
+        None => task.set_item("allow_retries", py.None())?,
+    }
+    match spec.max_task_attempts {
+        Some(max_task_attempts) => task.set_item("max_task_attempts", max_task_attempts)?,
+        None => task.set_item("max_task_attempts", py.None())?,
+    }
     if let Some(options) = spec.options.as_ref() {
         task.set_item("options", json_value_to_py(py, options)?)?;
     } else {
@@ -1225,6 +1271,14 @@ impl TaskInfo for RuntimeTaskWrapper {
 
     fn options(&self) -> Option<&Value> {
         self.inner.options()
+    }
+
+    fn allow_retries(&self) -> Option<bool> {
+        self.inner.allow_retries()
+    }
+
+    fn max_task_attempts(&self) -> Option<usize> {
+        self.inner.max_task_attempts()
     }
 }
 
@@ -1563,6 +1617,8 @@ mod tests {
 
             assert_eq!(spec.name, "backup_config");
             assert_eq!(spec.connection_plugin_name.as_deref(), Some("ssh"));
+            assert_eq!(spec.allow_retries, None);
+            assert_eq!(spec.max_task_attempts, None);
             assert_eq!(spec.options, None);
             assert_eq!(spec.sub_tasks.len(), 1);
             assert_eq!(spec.sub_tasks[0].name, "verify_backup");
@@ -1605,6 +1661,38 @@ mod tests {
                 spec.options,
                 Some(json!({"backup_path": "/tmp/configs", "compress": true}))
             );
+        });
+    }
+
+    #[test]
+    fn extract_python_task_spec_extracts_retry_overrides() {
+        init_python();
+        Python::attach(|py| {
+            let task = make_task_class(
+                py,
+                "backup_config",
+                Some("ssh"),
+                &[],
+                PythonTaskExecutionMode::Blocking,
+            )
+            .expect("task class should be created");
+            task.getattr("__genja_task_info__")
+                .expect("task metadata should exist")
+                .cast::<PyDict>()
+                .expect("task metadata should be a dict")
+                .set_item("allow_retries", true)
+                .unwrap();
+            task.getattr("__genja_task_info__")
+                .expect("task metadata should exist")
+                .cast::<PyDict>()
+                .expect("task metadata should be a dict")
+                .set_item("max_task_attempts", 3)
+                .unwrap();
+
+            let spec = extract_python_task_spec(task).expect("task spec should extract");
+
+            assert_eq!(spec.allow_retries, Some(true));
+            assert_eq!(spec.max_task_attempts, Some(3));
         });
     }
 

--- a/genja-core-python/src/task.rs
+++ b/genja-core-python/src/task.rs
@@ -1792,9 +1792,7 @@ mod tests {
                 .host_result("router1")
                 .expect("router1 result should exist");
             assert!(host_result.is_passed());
-            let success = host_result
-                .success()
-                .expect("host result should be passed");
+            let success = host_result.success().expect("host result should be passed");
             assert!(success.changed());
             assert_eq!(success.summary(), Some("async handled router1"));
             assert_eq!(success.metadata().unwrap()["has_connection"], json!(false));

--- a/genja-core/README.md
+++ b/genja-core/README.md
@@ -13,6 +13,7 @@ results, connection state, or processor behavior.
 - Inventory types for hosts, groups, host variables, and connection metadata
 - Settings models and file loading for JSON, YAML, and TOML configuration
 - Task traits, task metadata, task runtime context, and structured task results
+  with semantic outcomes plus host execution metadata
 - Connection state and task connection resolver traits for runtime integrations
 - Processor result handling used by task execution
 - Re-exported task authoring macros from `genja-core-derive`
@@ -77,3 +78,7 @@ impl CheckTask {
 For complete application examples, see the
 [quickstart guide](https://docs.genja.co.uk/quickstart/) and the top-level
 `genja` crate.
+
+Per-host task results are represented by `HostTaskResult`, which separates the
+semantic task outcome from host-level execution metadata such as timing and
+retry attempt state.

--- a/genja-core/src/inventory/models.rs
+++ b/genja-core/src/inventory/models.rs
@@ -422,7 +422,7 @@ impl<'de> Deserialize<'de> for ParentGroups {
         match deserializer.deserialize_seq(ParentGroupsVisitor) {
             Ok(parent) => Ok(parent),
             Err(err) => {
-                log::error!("{}", err);
+                log::error!("{err}");
                 let err_msg = "Groups should be an array of strings for use with `ParentGroups`";
                 log::error!("{err_msg}");
                 Err(D::Error::custom(err_msg))

--- a/genja-core/src/inventory/tests.rs
+++ b/genja-core/src/inventory/tests.rs
@@ -20,14 +20,14 @@ mod tests {
         let mut hosts = Hosts(CustomTreeMap::new());
         // hosts.insert("hosts".to_string(), CustomTreeMap::new());
         for i in 1..=10 {
-            let name = format!("host{}.example.com", i);
+            let name = format!("host{i}.example.com");
             let mut groups = ParentGroups::new();
             groups.push("cisco".to_string());
             let host = Host::builder()
                 .hostname(&name)
                 .port(2200 + i as u16)
-                .username(format!("user{}", i))
-                .password(format!("password{}", i))
+                .username(format!("user{i}"))
+                .password(format!("password{i}"))
                 .platform(if i % 2 == 0 { "linux" } else { "windows" })
                 .data(Data(serde_json::json!(vec![format!(
                     "data for host {}",
@@ -61,12 +61,12 @@ mod tests {
 
         // Add 10 hosts to the hosts map with dummy data
         for i in 1..=10 {
-            let name = format!("host{}.example.com", i);
+            let name = format!("host{i}.example.com");
             let host = Host::builder()
                 .hostname(&name)
                 .port(2200 + i as u16)
-                .username(format!("user{}", i))
-                .password(format!("password{}", i))
+                .username(format!("user{i}"))
+                .password(format!("password{i}"))
                 .platform(if i % 2 == 0 { "linux" } else { "windows" })
                 .data(Data(serde_json::json!(vec![format!(
                     "data for host {}",

--- a/genja-core/src/settings/env_defaults.rs
+++ b/genja-core/src/settings/env_defaults.rs
@@ -104,9 +104,7 @@ pub(super) fn raise_on_error() -> bool {
             Some(value) => value,
             None => {
                 log::warn!(
-                    "Invalid {} value {:?}; using default false",
-                    ENV_RAISE_ON_ERROR,
-                    s
+                    "Invalid {ENV_RAISE_ON_ERROR} value {s:?}; using default false"
                 );
                 false
             }
@@ -186,9 +184,7 @@ pub(super) fn get_log_to_console_default() -> bool {
             Some(value) => value,
             None => {
                 log::warn!(
-                    "Invalid {} value {:?}; using default false",
-                    ENV_LOG_TO_CONSOLE,
-                    val
+                    "Invalid {ENV_LOG_TO_CONSOLE} value {val:?}; using default false"
                 );
                 false
             }

--- a/genja-core/src/settings/env_defaults.rs
+++ b/genja-core/src/settings/env_defaults.rs
@@ -160,6 +160,16 @@ pub(super) fn get_runner_max_connection_attempts_default() -> usize {
     3
 }
 
+/// Returns the default task retry authorization for runner execution.
+pub(super) fn get_runner_allow_retries_default() -> bool {
+    false
+}
+
+/// Returns the default maximum number of task attempts for runner execution.
+pub(super) fn get_runner_max_task_attempts_default() -> usize {
+    1
+}
+
 /// Returns the default log level from `GENJA_LOGGING_LEVEL`, or "info".
 ///
 /// See tests in this module for behavioral verification.

--- a/genja-core/src/settings/env_defaults.rs
+++ b/genja-core/src/settings/env_defaults.rs
@@ -103,9 +103,7 @@ pub(super) fn raise_on_error() -> bool {
         Ok(s) => match parse_bool_loose(s.as_str()) {
             Some(value) => value,
             None => {
-                log::warn!(
-                    "Invalid {ENV_RAISE_ON_ERROR} value {s:?}; using default false"
-                );
+                log::warn!("Invalid {ENV_RAISE_ON_ERROR} value {s:?}; using default false");
                 false
             }
         },
@@ -183,9 +181,7 @@ pub(super) fn get_log_to_console_default() -> bool {
         Ok(val) => match parse_bool_loose(val.as_str()) {
             Some(value) => value,
             None => {
-                log::warn!(
-                    "Invalid {ENV_LOG_TO_CONSOLE} value {val:?}; using default false"
-                );
+                log::warn!("Invalid {ENV_LOG_TO_CONSOLE} value {val:?}; using default false");
                 false
             }
         },

--- a/genja-core/src/settings/runner.rs
+++ b/genja-core/src/settings/runner.rs
@@ -1,5 +1,6 @@
 use super::env_defaults::{
-    get_runner_max_connection_attempts_default, get_runner_max_task_depth_default,
+    get_runner_allow_retries_default, get_runner_max_connection_attempts_default,
+    get_runner_max_task_attempts_default, get_runner_max_task_depth_default,
     get_runner_options_default, get_runner_plugin_default,
 };
 use serde::{Deserialize, Serialize};
@@ -7,8 +8,9 @@ use serde::{Deserialize, Serialize};
 /// Task runner configuration.
 ///
 /// The plugin name defaults from `GENJA_RUNNER_PLUGIN`. `worker_count`,
-/// `max_task_depth`, and `max_connection_attempts` control built-in runner
-/// behavior; `options` carries plugin-specific JSON for custom runners.
+/// `max_task_depth`, `max_connection_attempts`, `allow_retries`, and
+/// `max_task_attempts` control built-in runner behavior; `options` carries
+/// plugin-specific JSON for custom runners.
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(default)]
 pub struct RunnerConfig {
@@ -17,6 +19,8 @@ pub struct RunnerConfig {
     worker_count: Option<usize>,
     max_task_depth: usize,
     max_connection_attempts: usize,
+    allow_retries: bool,
+    max_task_attempts: usize,
 }
 
 impl Default for RunnerConfig {
@@ -27,6 +31,8 @@ impl Default for RunnerConfig {
             worker_count: None,
             max_task_depth: get_runner_max_task_depth_default(),
             max_connection_attempts: get_runner_max_connection_attempts_default(),
+            allow_retries: get_runner_allow_retries_default(),
+            max_task_attempts: get_runner_max_task_attempts_default(),
         }
     }
 }
@@ -55,6 +61,14 @@ impl RunnerConfig {
     pub fn max_connection_attempts(&self) -> usize {
         self.max_connection_attempts
     }
+
+    pub fn allow_retries(&self) -> bool {
+        self.allow_retries
+    }
+
+    pub fn max_task_attempts(&self) -> usize {
+        self.max_task_attempts
+    }
 }
 
 /// Builder for `RunnerConfig`.
@@ -65,6 +79,8 @@ pub struct RunnerConfigBuilder {
     worker_count: Option<usize>,
     max_task_depth: Option<usize>,
     max_connection_attempts: Option<usize>,
+    allow_retries: Option<bool>,
+    max_task_attempts: Option<usize>,
 }
 
 impl RunnerConfigBuilder {
@@ -93,6 +109,16 @@ impl RunnerConfigBuilder {
         self
     }
 
+    pub fn allow_retries(mut self, allow_retries: bool) -> Self {
+        self.allow_retries = Some(allow_retries);
+        self
+    }
+
+    pub fn max_task_attempts(mut self, max_task_attempts: usize) -> Self {
+        self.max_task_attempts = Some(max_task_attempts);
+        self
+    }
+
     pub fn build(self) -> RunnerConfig {
         RunnerConfig {
             plugin: self.plugin.unwrap_or_else(get_runner_plugin_default),
@@ -104,6 +130,12 @@ impl RunnerConfigBuilder {
             max_connection_attempts: self
                 .max_connection_attempts
                 .unwrap_or_else(get_runner_max_connection_attempts_default),
+            allow_retries: self
+                .allow_retries
+                .unwrap_or_else(get_runner_allow_retries_default),
+            max_task_attempts: self
+                .max_task_attempts
+                .unwrap_or_else(get_runner_max_task_attempts_default),
         }
     }
 }

--- a/genja-core/src/settings/tests.rs
+++ b/genja-core/src/settings/tests.rs
@@ -212,6 +212,8 @@ fn runner_config_default_values() {
     assert_eq!(runner.worker_count(), None);
     assert_eq!(runner.max_task_depth(), 10);
     assert_eq!(runner.max_connection_attempts(), 3);
+    assert!(!runner.allow_retries());
+    assert_eq!(runner.max_task_attempts(), 1);
 }
 
 #[test]
@@ -222,6 +224,8 @@ fn runner_config_deserializes_empty_object_to_defaults() {
     assert_eq!(runner.worker_count(), None);
     assert_eq!(runner.max_task_depth(), 10);
     assert_eq!(runner.max_connection_attempts(), 3);
+    assert!(!runner.allow_retries());
+    assert_eq!(runner.max_task_attempts(), 1);
 }
 
 #[test]
@@ -231,7 +235,9 @@ fn runner_config_deserializes_with_values() {
         "options": {"queue": "fast", "strategy": "burst"},
         "worker_count": 6,
         "max_task_depth": 5,
-        "max_connection_attempts": 7
+        "max_connection_attempts": 7,
+        "allow_retries": true,
+        "max_task_attempts": 4
     }"#;
     let runner: RunnerConfig = serde_json::from_str(json).unwrap();
     assert_eq!(runner.plugin(), "custom");
@@ -242,6 +248,8 @@ fn runner_config_deserializes_with_values() {
     assert_eq!(runner.worker_count(), Some(6));
     assert_eq!(runner.max_task_depth(), 5);
     assert_eq!(runner.max_connection_attempts(), 7);
+    assert!(runner.allow_retries());
+    assert_eq!(runner.max_task_attempts(), 4);
 }
 
 #[test]
@@ -249,6 +257,17 @@ fn runner_config_builder_sets_max_connection_attempts() {
     let runner = RunnerConfig::builder().max_connection_attempts(9).build();
 
     assert_eq!(runner.max_connection_attempts(), 9);
+}
+
+#[test]
+fn runner_config_builder_sets_retry_controls() {
+    let runner = RunnerConfig::builder()
+        .allow_retries(true)
+        .max_task_attempts(5)
+        .build();
+
+    assert!(runner.allow_retries());
+    assert_eq!(runner.max_task_attempts(), 5);
 }
 
 #[test]
@@ -472,6 +491,8 @@ runner:
   worker_count: 6
   max_task_depth: 5
   max_connection_attempts: 7
+  allow_retries: true
+  max_task_attempts: 4
 logging:
   enabled: "no"
   level: "debug"
@@ -529,6 +550,8 @@ logging:
     assert_eq!(settings.runner().worker_count(), Some(6));
     assert_eq!(settings.runner().max_task_depth(), 5);
     assert_eq!(settings.runner().max_connection_attempts(), 7);
+    assert!(settings.runner().allow_retries());
+    assert_eq!(settings.runner().max_task_attempts(), 4);
     assert!(!settings.logging().enabled());
     assert_eq!(settings.logging().level(), "debug");
     assert_eq!(settings.logging().log_file(), "./custom.log");

--- a/genja-core/src/state.rs
+++ b/genja-core/src/state.rs
@@ -336,7 +336,7 @@ impl State {
         K: Into<NatString>,
     {
         let name = name.into();
-        warn!("host '{}' marked as failed", name);
+        warn!("host '{name}' marked as failed");
         self.host_status.insert(name, HostStatus::Failed);
     }
 

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -1902,23 +1902,8 @@ impl HostTaskResult {
             .with_started_at(started_at)
             .with_finished_at(finished_at)
             .with_duration_ns(duration_ns);
-        let outcome = match self.outcome {
-            HostTaskOutcome::Passed(success) => HostTaskOutcome::Passed(
-                success
-                    .with_started_at(started_at)
-                    .with_finished_at(finished_at)
-                    .with_duration_ns(duration_ns),
-            ),
-            HostTaskOutcome::Failed(failure) => HostTaskOutcome::Failed(
-                failure
-                    .with_started_at(started_at)
-                    .with_finished_at(finished_at)
-                    .with_duration_ns(duration_ns),
-            ),
-            HostTaskOutcome::Skipped(skip) => HostTaskOutcome::Skipped(skip),
-        };
         Self {
-            outcome,
+            outcome: self.outcome,
             execution_metadata,
         }
     }
@@ -1927,7 +1912,7 @@ impl HostTaskResult {
 /// Represents the successful execution of a task on a host.
 ///
 /// `TaskSuccess` captures detailed information about a task that completed successfully,
-/// including the execution result, whether changes were made, timing information, and any
+/// including the execution result, whether changes were made, and any
 /// warnings or messages generated during execution. This structure provides a comprehensive
 /// view of what happened during task execution, even when the task succeeded.
 ///
@@ -1952,12 +1937,6 @@ impl HostTaskResult {
 ///
 /// * `metadata` - Additional structured metadata about the execution, such as version information,
 ///   configuration details, or other contextual data.
-///
-/// * `started_at` - The timestamp when the task execution started, if available.
-///
-/// * `finished_at` - The timestamp when the task execution finished, if available.
-///
-/// * `duration_ms` - The duration of the task execution in milliseconds, if available.
 ///
 /// # Example
 ///
@@ -1984,10 +1963,6 @@ pub struct TaskSuccess {
     warnings: Vec<String>,
     messages: Vec<TaskMessage>,
     metadata: Option<Value>,
-    started_at: Option<SystemTime>,
-    finished_at: Option<SystemTime>,
-    duration_ns: Option<u128>,
-    duration_ms: Option<u128>,
 }
 
 impl TaskSuccess {
@@ -1995,7 +1970,7 @@ impl TaskSuccess {
     ///
     /// This constructor initializes a `TaskSuccess` with all fields set to their default values:
     /// no result data, no changes made, no diff, no summary, empty warnings and messages lists,
-    /// no metadata, and no timing information.
+    /// no metadata.
     ///
     /// # Returns
     ///
@@ -2140,65 +2115,6 @@ impl TaskSuccess {
         self
     }
 
-    /// Sets the task execution start timestamp.
-    ///
-    /// This is a builder method that consumes `self` and returns the modified instance,
-    /// allowing for method chaining.
-    ///
-    /// # Parameters
-    ///
-    /// * `started_at` - The timestamp when the task execution started.
-    ///
-    /// # Returns
-    ///
-    /// The modified `TaskSuccess` instance with the start timestamp set.
-    pub fn with_started_at(mut self, started_at: SystemTime) -> Self {
-        self.started_at = Some(started_at);
-        self
-    }
-
-    /// Sets the task execution finish timestamp.
-    ///
-    /// This is a builder method that consumes `self` and returns the modified instance,
-    /// allowing for method chaining.
-    ///
-    /// # Parameters
-    ///
-    /// * `finished_at` - The timestamp when the task execution finished.
-    ///
-    /// # Returns
-    ///
-    /// The modified `TaskSuccess` instance with the finish timestamp set.
-    pub fn with_finished_at(mut self, finished_at: SystemTime) -> Self {
-        self.finished_at = Some(finished_at);
-        self
-    }
-
-    /// Sets the task execution duration in milliseconds.
-    ///
-    /// This is a builder method that consumes `self` and returns the modified instance,
-    /// allowing for method chaining.
-    ///
-    /// # Parameters
-    ///
-    /// * `duration_ms` - The duration of the task execution in milliseconds.
-    ///
-    /// # Returns
-    ///
-    /// The modified `TaskSuccess` instance with the duration set.
-    pub fn with_duration_ms(mut self, duration_ms: u128) -> Self {
-        self.duration_ns = Some(duration_ms.saturating_mul(1_000_000));
-        self.duration_ms = Some(duration_ms);
-        self
-    }
-
-    /// Sets the task execution duration in nanoseconds.
-    pub fn with_duration_ns(mut self, duration_ns: u128) -> Self {
-        self.duration_ns = Some(duration_ns);
-        self.duration_ms = Some(duration_ns / 1_000_000);
-        self
-    }
-
     /// Returns the structured result data produced by the task, if available.
     ///
     /// # Returns
@@ -2264,57 +2180,6 @@ impl TaskSuccess {
         self.metadata.as_ref()
     }
 
-    /// Returns the task execution start timestamp, if available.
-    ///
-    /// # Returns
-    ///
-    /// `Some(SystemTime)` if the start timestamp was set, `None` otherwise.
-    pub fn started_at(&self) -> Option<SystemTime> {
-        self.started_at
-    }
-
-    /// Returns the task execution finish timestamp, if available.
-    ///
-    /// # Returns
-    ///
-    /// `Some(SystemTime)` if the finish timestamp was set, `None` otherwise.
-    pub fn finished_at(&self) -> Option<SystemTime> {
-        self.finished_at
-    }
-
-    /// Returns the task execution duration in milliseconds, if available.
-    ///
-    /// # Returns
-    ///
-    /// `Some(u128)` if the duration was set, `None` otherwise.
-    pub fn duration_ms(&self) -> Option<u128> {
-        self.duration_ns
-            .map(|duration_ns| duration_ns / 1_000_000)
-            .or(self.duration_ms)
-    }
-
-    /// Returns the task execution duration in nanoseconds, if available.
-    pub fn duration_ns(&self) -> Option<u128> {
-        self.duration_ns.or_else(|| {
-            self.duration_ms
-                .map(|duration_ms| duration_ms.saturating_mul(1_000_000))
-        })
-    }
-
-    /// Returns the task execution start timestamp in RFC 3339 format, if available.
-    pub fn started_at_display(&self) -> Option<String> {
-        self.started_at.map(format_timestamp_display)
-    }
-
-    /// Returns the task execution finish timestamp in RFC 3339 format, if available.
-    pub fn finished_at_display(&self) -> Option<String> {
-        self.finished_at.map(format_timestamp_display)
-    }
-
-    /// Returns the task execution duration in a human-readable format, if available.
-    pub fn duration_display(&self) -> Option<String> {
-        self.duration_ns().map(format_duration_display)
-    }
 }
 
 /// Represents a failed task execution with comprehensive error information and context.
@@ -2324,7 +2189,7 @@ impl TaskSuccess {
 /// execution before the failure occurred. This structure provides rich context for error handling,
 /// logging, and determining whether a failed task should be retried.
 ///
-/// The failure information includes timing data, structured details about the error, and the
+/// The failure information includes structured details about the error, and the
 /// ability to downcast to specific error types for specialized error handling.
 ///
 /// # Fields
@@ -2352,13 +2217,6 @@ impl TaskSuccess {
 ///
 /// * `messages` - Structured messages with levels (Info, Warning, Error, Debug) that were
 ///   collected during execution, providing a detailed execution trace up to the point of failure.
-///
-/// * `started_at` - The timestamp when the task execution started, if available.
-///
-/// * `finished_at` - The timestamp when the task execution failed, if available.
-///
-/// * `duration_ms` - The duration of the task execution in milliseconds before it failed,
-///   if available.
 ///
 /// # Example
 ///
@@ -2391,10 +2249,6 @@ pub struct TaskFailure {
     details: Option<Value>,
     warnings: Vec<String>,
     messages: Vec<TaskMessage>,
-    started_at: Option<SystemTime>,
-    finished_at: Option<SystemTime>,
-    duration_ns: Option<u128>,
-    duration_ms: Option<u128>,
 }
 
 impl TaskFailure {
@@ -2403,7 +2257,7 @@ impl TaskFailure {
     /// This constructor wraps any error type that implements the standard `Error` trait
     /// in a `TaskFailure`, capturing the error message and type information. The failure
     /// is initialized with default values: classified as `Internal`, not retryable, with
-    /// no additional details, warnings, or messages, and no timing information.
+    /// no additional details, warnings, or messages.
     ///
     /// The error is stored as a thread-safe, reference-counted pointer (`Arc<dyn Error>`),
     /// allowing it to be cloned and shared across threads while preserving the ability
@@ -2440,10 +2294,6 @@ impl TaskFailure {
             details: None,
             warnings: Vec::new(),
             messages: Vec::new(),
-            started_at: None,
-            finished_at: None,
-            duration_ns: None,
-            duration_ms: None,
         }
     }
 
@@ -2477,10 +2327,6 @@ impl TaskFailure {
             details: None,
             warnings: Vec::new(),
             messages: Vec::new(),
-            started_at: None,
-            finished_at: None,
-            duration_ns: None,
-            duration_ms: None,
         }
     }
 
@@ -2500,10 +2346,6 @@ impl TaskFailure {
             details: None,
             warnings: Vec::new(),
             messages: Vec::new(),
-            started_at: None,
-            finished_at: None,
-            duration_ns: None,
-            duration_ms: None,
         }
     }
 
@@ -2600,65 +2442,6 @@ impl TaskFailure {
     /// The modified `TaskFailure` instance with the message added to the messages list.
     pub fn with_message(mut self, message: TaskMessage) -> Self {
         self.messages.push(message);
-        self
-    }
-
-    /// Sets the task execution start timestamp.
-    ///
-    /// This is a builder method that consumes `self` and returns the modified instance,
-    /// allowing for method chaining.
-    ///
-    /// # Parameters
-    ///
-    /// * `started_at` - The timestamp when the task execution started.
-    ///
-    /// # Returns
-    ///
-    /// The modified `TaskFailure` instance with the start timestamp set.
-    pub fn with_started_at(mut self, started_at: SystemTime) -> Self {
-        self.started_at = Some(started_at);
-        self
-    }
-
-    /// Sets the task execution finish timestamp.
-    ///
-    /// This is a builder method that consumes `self` and returns the modified instance,
-    /// allowing for method chaining.
-    ///
-    /// # Parameters
-    ///
-    /// * `finished_at` - The timestamp when the task execution failed.
-    ///
-    /// # Returns
-    ///
-    /// The modified `TaskFailure` instance with the finish timestamp set.
-    pub fn with_finished_at(mut self, finished_at: SystemTime) -> Self {
-        self.finished_at = Some(finished_at);
-        self
-    }
-
-    /// Sets the task execution duration in milliseconds.
-    ///
-    /// This is a builder method that consumes `self` and returns the modified instance,
-    /// allowing for method chaining.
-    ///
-    /// # Parameters
-    ///
-    /// * `duration_ms` - The duration of the task execution in milliseconds before it failed.
-    ///
-    /// # Returns
-    ///
-    /// The modified `TaskFailure` instance with the duration set.
-    pub fn with_duration_ms(mut self, duration_ms: u128) -> Self {
-        self.duration_ns = Some(duration_ms.saturating_mul(1_000_000));
-        self.duration_ms = Some(duration_ms);
-        self
-    }
-
-    /// Sets the task execution duration in nanoseconds.
-    pub fn with_duration_ns(mut self, duration_ns: u128) -> Self {
-        self.duration_ns = Some(duration_ns);
-        self.duration_ms = Some(duration_ns / 1_000_000);
         self
     }
 
@@ -2770,57 +2553,6 @@ impl TaskFailure {
         &self.messages
     }
 
-    /// Returns the task execution start timestamp, if available.
-    ///
-    /// # Returns
-    ///
-    /// `Some(SystemTime)` if the start timestamp was set, `None` otherwise.
-    pub fn started_at(&self) -> Option<SystemTime> {
-        self.started_at
-    }
-
-    /// Returns the task execution finish timestamp, if available.
-    ///
-    /// # Returns
-    ///
-    /// `Some(SystemTime)` if the finish timestamp was set, `None` otherwise.
-    pub fn finished_at(&self) -> Option<SystemTime> {
-        self.finished_at
-    }
-
-    /// Returns the task execution duration in milliseconds, if available.
-    ///
-    /// # Returns
-    ///
-    /// `Some(u128)` if the duration was set, `None` otherwise.
-    pub fn duration_ms(&self) -> Option<u128> {
-        self.duration_ns
-            .map(|duration_ns| duration_ns / 1_000_000)
-            .or(self.duration_ms)
-    }
-
-    /// Returns the task execution duration in nanoseconds, if available.
-    pub fn duration_ns(&self) -> Option<u128> {
-        self.duration_ns.or_else(|| {
-            self.duration_ms
-                .map(|duration_ms| duration_ms.saturating_mul(1_000_000))
-        })
-    }
-
-    /// Returns the task execution start timestamp in RFC 3339 format, if available.
-    pub fn started_at_display(&self) -> Option<String> {
-        self.started_at.map(format_timestamp_display)
-    }
-
-    /// Returns the task execution finish timestamp in RFC 3339 format, if available.
-    pub fn finished_at_display(&self) -> Option<String> {
-        self.finished_at.map(format_timestamp_display)
-    }
-
-    /// Returns the task execution duration in a human-readable format, if available.
-    pub fn duration_display(&self) -> Option<String> {
-        self.duration_ns().map(format_duration_display)
-    }
 }
 
 /// Represents information about a skipped task execution.
@@ -3960,11 +3692,7 @@ impl TaskDefinition {
             );
             results.record_execution_timing(started_at, finished_at);
             let mut host_result = HostTaskResult::failed(
-                TaskFailure::new(error)
-                    .with_kind(TaskFailureKind::Internal)
-                    .with_started_at(started_at)
-                    .with_finished_at(finished_at)
-                    .with_duration_ns(0),
+                TaskFailure::new(error).with_kind(TaskFailureKind::Internal),
             )
             .with_execution_timing(started_at, finished_at, 0);
             *host_result.execution_metadata_mut() = host_result
@@ -4015,11 +3743,7 @@ impl TaskDefinition {
                     );
 
                     let mut host_result = HostTaskResult::failed(
-                        TaskFailure::new(error)
-                        .with_kind(TaskFailureKind::Connection)
-                        .with_started_at(started_at)
-                        .with_finished_at(finished_at)
-                        .with_duration_ns(duration_ns),
+                        TaskFailure::new(error).with_kind(TaskFailureKind::Connection),
                     );
                     host_result = host_result.with_execution_timing(started_at, finished_at, duration_ns);
                     *host_result.execution_metadata_mut() = host_result
@@ -4135,15 +3859,10 @@ impl TaskDefinition {
             .with_attempts(attempts)
             .with_retried(attempts > 1)
             .with_retry_exhausted(retry_exhausted);
-        let duration_display = match host_result.outcome() {
-            HostTaskOutcome::Passed(success) => success
-                .duration_display()
-                .unwrap_or_else(|| format_duration_display(duration_ns)),
-            HostTaskOutcome::Failed(failure) => failure
-                .duration_display()
-                .unwrap_or_else(|| format_duration_display(duration_ns)),
-            HostTaskOutcome::Skipped(_) => format_duration_display(duration_ns),
-        };
+        let duration_display = host_result
+            .execution_metadata()
+            .duration_display()
+            .unwrap_or_else(|| format_duration_display(duration_ns));
 
         info!(
             "finished task '{}' for host '{}' with status={} duration_ms={} duration={}",
@@ -4795,15 +4514,20 @@ mod tests {
             .sub_task("leaf")
             .expect("leaf task should capture failure");
 
-        let failure = level_five
+        let host_result = level_five
             .host_result("router1")
-            .and_then(HostTaskResult::failure)
+            .expect("depth overflow host result should exist");
+        let failure = host_result
+            .failure()
             .expect("depth overflow should be recorded as a host failure");
         assert!(failure.message().contains("max task depth exceeded"));
         assert!(matches!(failure.kind(), TaskFailureKind::Internal));
-        assert!(failure.started_at().is_some());
-        assert!(failure.finished_at().is_some());
-        assert_eq!(failure.duration_ns(), Some(0));
+        assert!(host_result.execution_metadata().started_at().is_some());
+        assert_eq!(
+            host_result.execution_metadata().started_at(),
+            host_result.execution_metadata().finished_at()
+        );
+        assert_eq!(host_result.execution_metadata().duration_ns(), Some(0));
     }
 
     #[test]
@@ -4819,14 +4543,14 @@ mod tests {
 
         run_async(task.start("router1", &host, &mut results, 0)).expect("start should succeed");
 
-        let success = results
+        let host_result = results
             .host_result("router1")
-            .and_then(HostTaskResult::success)
-            .expect("host result should be passed");
-        assert!(success.started_at().is_some());
-        assert!(success.finished_at().is_some());
-        assert!(success.duration_ns().is_some());
-        assert!(success.duration_display().is_some());
+            .expect("host result should exist");
+        assert!(host_result.is_passed());
+        assert!(host_result.execution_metadata().started_at().is_some());
+        assert!(host_result.execution_metadata().finished_at().is_some());
+        assert!(host_result.execution_metadata().duration_ns().is_some());
+        assert!(host_result.execution_metadata().duration_display().is_some());
     }
 
     #[test]
@@ -4838,14 +4562,14 @@ mod tests {
         run_async(task.start("router1", &host, &mut results, 0))
             .expect("start should record a failed result");
 
-        let failure = results
+        let host_result = results
             .host_result("router1")
-            .and_then(HostTaskResult::failure)
-            .expect("host result should be failed");
-        assert!(failure.started_at().is_some());
-        assert!(failure.finished_at().is_some());
-        assert!(failure.duration_ns().is_some());
-        assert!(failure.duration_display().is_some());
+            .expect("host result should exist");
+        assert!(host_result.is_failed());
+        assert!(host_result.execution_metadata().started_at().is_some());
+        assert!(host_result.execution_metadata().finished_at().is_some());
+        assert!(host_result.execution_metadata().duration_ns().is_some());
+        assert!(host_result.execution_metadata().duration_display().is_some());
     }
 
     #[test]
@@ -5150,10 +4874,6 @@ mod tests {
 
     #[test]
     fn task_success_builders_expose_extended_metadata() {
-        let started_at = SystemTime::UNIX_EPOCH;
-        let finished_at = SystemTime::UNIX_EPOCH
-            .checked_add(std::time::Duration::from_secs(2))
-            .expect("valid timestamp");
         let success = TaskSuccess::new()
             .with_result(json!({"ok": true}))
             .with_changed(true)
@@ -5163,10 +4883,7 @@ mod tests {
             .with_message(
                 TaskMessage::new(MessageLevel::Info, "commit complete").with_code("commit_ok"),
             )
-            .with_metadata(json!({"version": 1}))
-            .with_started_at(started_at)
-            .with_finished_at(finished_at)
-            .with_duration_ms(2000);
+            .with_metadata(json!({"version": 1}));
 
         assert_eq!(success.result(), Some(&json!({"ok": true})));
         assert!(success.changed());
@@ -5177,9 +4894,6 @@ mod tests {
         assert_eq!(success.messages()[0].code(), Some("commit_ok"));
         assert!(matches!(success.messages()[0].level(), MessageLevel::Info));
         assert_eq!(success.metadata(), Some(&json!({"version": 1})));
-        assert_eq!(success.started_at(), Some(started_at));
-        assert_eq!(success.finished_at(), Some(finished_at));
-        assert_eq!(success.duration_ms(), Some(2000));
     }
 
     #[test]

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -15,11 +15,11 @@
 //!   [`TaskDefinition`] values. Each root task may own its own sub-task tree, so a
 //!   `Tasks` value represents a forest of task trees.
 //! - **Task Execution**: Tasks execute against hosts and return [`HostTaskResult`]
-//!   indicating success, failure, or skip status.
+//!   values with a semantic [`HostTaskOutcome`] and separate [`HostExecutionMetadata`].
 //! - **Result Tracking**: The [`TaskResults`] structure maintains a hierarchical tree
 //!   of execution results for tasks and their sub-tasks across all hosts.
-//! - **Rich Metadata**: Tasks can attach detailed metadata including timing information,
-//!   warnings, messages, diffs, and custom data to their results.
+//! - **Rich Metadata**: Tasks can attach detailed metadata including per-host execution
+//!   timing, retry state, warnings, messages, diffs, and custom data to their results.
 //! - **Summaries and Serialization**: Task results can be aggregated with
 //!   [`TaskResults::host_summary`] and [`TaskResults::task_summary`], then exported in
 //!   either human-readable or raw JSON forms.
@@ -114,12 +114,12 @@
 //!    ┌──────────────────────────────────────────────────────────┐
 //!    │ TaskResults (per task)                                   │
 //!    │                                                          │
-//!    │  ┌─────────────────────────────────────────┐             │
-//!    │  │ Host Results (Map<hostname, result>)    │             │
-//!    │  │  - router1 → HostTaskResult::Passed     │             │
-//!    │  │  - router2 → HostTaskResult::Failed     │             │
-//!    │  │  - router3 → HostTaskResult::Skipped    │             │
-//!    │  └─────────────────────────────────────────┘             │
+//!    │  ┌───────────────────────────────────────────┐           │
+//!    │  │ Host Results (Map<hostname, result>)      │           │
+//!    │  │  - router1 → {outcome: Passed,  metadata} │           │
+//!    │  │  - router2 → {outcome: Failed,  metadata} │           │
+//!    │  │  - router3 → {outcome: Skipped, metadata} │           │
+//!    │  └───────────────────────────────────────────┘           │
 //!    │                                                          │
 //!    │  ┌───────────────────────────────────────────┐           │
 //!    │  │ Sub-task Results (Map<name, TaskResults>) │           │
@@ -168,8 +168,8 @@
 //!    task execution across selected hosts:
 //!    - Optionally resolves a task-scoped connection via [`TaskConnectionResolver`]
 //!    - Calls [`Task::start`] for each host with a [`TaskRuntimeContext`]
-//!    - Records timing information (start, finish, duration)
-//!    - Captures results (success, failure, or skip)
+//!    - Records execution metadata (start, finish, duration, retry state)
+//!    - Captures semantic outcomes (success, failure, or skip)
 //!    - Recursively processes sub-tasks up to `max_depth`
 //!
 //! 4. **Result Collection**: Each host produces a `HostTaskResult` that is stored in
@@ -328,8 +328,9 @@
 //! - Sub-task results are grouped by sub-task name. The `TaskResults` node for a
 //!   given sub-task contains per-host results accumulated across all hosts.
 //! - The framework does not automatically skip sub-tasks when a parent fails or is
-//!   skipped. If you want that behavior, return an explicit [`HostTaskResult::Skipped`]
-//!   from the sub-task or encode the condition in the task itself.
+//!   skipped. If you want that behavior, return a [`HostTaskResult`] with
+//!   [`HostTaskOutcome::Skipped`] from the sub-task or encode the condition in the task
+//!   itself.
 //! - Processor hooks run only for tasks that selected processor names. The root
 //!   task can also be given processor names through [`TaskDefinition::with_processor`]
 //!   or [`TaskDefinition::with_processors`].
@@ -342,34 +343,40 @@
 //!   stops and propagates that error.
 //! - `max_depth` is checked using `depth > max_depth`. This means `max_depth = 0`
 //!   still allows the root task at depth `0`, but rejects all sub-tasks at depth `1`.
-//! - Exceeding `max_depth` records an internal [`HostTaskResult::Failed`] for the host
-//!   at that task node instead of returning an outer execution error.
+//! - Exceeding `max_depth` records a failed [`HostTaskResult`] with
+//!   [`HostTaskOutcome::Failed`] for the host at that task node instead of returning an
+//!   outer execution error.
 //! - If [`Task::start`] returns [`TaskError`], the framework captures it as a
-//!   [`TaskFailure`] with timing metadata and stores it in the host results tree.
+//!   [`TaskFailure`] and stores it inside a [`HostTaskResult`] together with host-level
+//!   execution metadata.
 //!
 //! # Task Results
 //!
 //! ## [`HostTaskResult`]
 //!
-//! Represents the outcome of executing a task on a single host. It can be:
+//! Represents the result of executing a task on a single host.
 //!
-//! - **Passed**: Task completed successfully with optional metadata in [`TaskSuccess`]
-//! - **Failed**: Task encountered an error with details in [`TaskFailure`]
-//! - **Skipped**: Task was not executed with reason in [`TaskSkip`]
+//! [`HostTaskResult`] combines:
+//!
+//! - A semantic [`HostTaskOutcome`] of passed, failed, or skipped
+//! - Host-level [`HostExecutionMetadata`] for timing and retry state
 //!
 //! ```rust
-//! use genja_core::task::{HostTaskResult, TaskSuccess, TaskFailure, TaskFailureKind};
+//! use genja_core::task::{
+//!     HostTaskOutcome, HostTaskResult, TaskFailure, TaskFailureKind, TaskSuccess,
+//! };
 //! use serde_json::json;
 //!
-//! // Success with metadata
+//! // Success with semantic task data.
 //! let success = HostTaskResult::passed(
 //!     TaskSuccess::new()
 //!         .with_result(json!({"status": "deployed"}))
 //!         .with_changed(true)
 //!         .with_diff("+ new_config_line")
 //! );
+//! assert!(matches!(success.outcome(), HostTaskOutcome::Passed(_)));
 //!
-//! // Failure with classification
+//! // Failure with classification and retry hint.
 //! let failure = HostTaskResult::failed(
 //!     TaskFailure::new(std::io::Error::new(
 //!         std::io::ErrorKind::ConnectionRefused,
@@ -378,9 +385,14 @@
 //!     .with_kind(TaskFailureKind::Connection)
 //!     .with_retryable(true)
 //! );
+//! assert!(matches!(failure.outcome(), HostTaskOutcome::Failed(_)));
 //!
-//! // Skipped with reason
+//! // Skipped with reason.
 //! let skipped = HostTaskResult::skipped_with_reason("parent_failed");
+//! assert!(matches!(skipped.outcome(), HostTaskOutcome::Skipped(_)));
+//!
+//! // Execution timing and retry counts live outside the outcome payload.
+//! assert_eq!(success.execution_metadata().attempts(), 1);
 //! ```
 //!
 //! ## [`TaskResults`]
@@ -1541,31 +1553,21 @@ impl TaskResults {
     }
 }
 
-/// Represents the execution outcome of a task on a single host.
+/// Represents the result of executing a task on a single host.
 ///
-/// `HostTaskResult` captures one of three possible states for a task execution:
-/// - **Passed**: The task completed successfully, potentially with changes, warnings, or metadata.
-/// - **Failed**: The task encountered an error and could not complete successfully.
-/// - **Skipped**: The task was not executed, typically due to conditional logic or dependencies.
+/// `HostTaskResult` separates the semantic task outcome from transport-style execution
+/// details:
+/// - [`HostTaskOutcome`] stores whether the task passed, failed, or was skipped, along with
+///   the corresponding payload.
+/// - [`HostExecutionMetadata`] stores execution timing and retry attempt data for that host.
 ///
-/// This enum provides a type-safe way to represent task outcomes and includes helper methods
-/// to query the result state and extract the underlying success, failure, or skip details.
-///
-/// # Variants
-///
-/// * `Passed(TaskSuccess)` - The task executed successfully. Contains detailed information about
-///   the execution including any results, changes made, warnings, and timing information.
-///
-/// * `Failed(TaskFailure)` - The task failed during execution. Contains error information,
-///   failure classification, retry hints, and any warnings or messages collected before failure.
-///
-/// * `Skipped(TaskSkip)` - The task was skipped and not executed. Contains optional reason
-///   and message explaining why the task was skipped.
+/// This keeps success and failure payloads focused on task semantics, while the surrounding
+/// host result carries cross-cutting execution metadata.
 ///
 /// # Example
 ///
 /// ```rust
-/// use genja_core::task::{HostTaskResult, TaskSuccess, TaskFailure};
+/// use genja_core::task::{HostTaskOutcome, HostTaskResult, TaskSuccess};
 ///
 /// // Create a successful result
 /// let success = HostTaskResult::passed(
@@ -1582,6 +1584,7 @@ impl TaskResults {
 /// if let Some(details) = success.success() {
 ///     assert!(details.changed());
 /// }
+/// assert!(matches!(success.outcome(), HostTaskOutcome::Passed(_)));
 ///
 /// // Create a skipped result
 /// let skipped = HostTaskResult::skipped_with_reason("Host in maintenance mode");
@@ -1715,12 +1718,12 @@ impl HostTaskResult {
     ///
     /// # Parameters
     ///
-    /// * `result` - The `TaskSuccess` containing details about the successful execution,
-    ///   including any results, changes made, warnings, and timing information.
+    /// * `result` - The `TaskSuccess` containing semantic success details such as result
+    ///   data, change state, warnings, and task-specific metadata.
     ///
     /// # Returns
     ///
-    /// A `HostTaskResult::Passed` variant containing the provided success details.
+    /// A `HostTaskResult` containing a passed outcome with the provided success details.
     pub fn passed(result: TaskSuccess) -> Self {
         Self {
             outcome: HostTaskOutcome::Passed(result),
@@ -1735,12 +1738,12 @@ impl HostTaskResult {
     ///
     /// # Parameters
     ///
-    /// * `failure` - The `TaskFailure` containing error information, failure classification,
-    ///   retry hints, and any warnings or messages collected before failure.
+    /// * `failure` - The `TaskFailure` containing semantic failure information,
+    ///   classification, retry hints, and any warnings or messages collected before failure.
     ///
     /// # Returns
     ///
-    /// A `HostTaskResult::Failed` variant containing the provided failure details.
+    /// A `HostTaskResult` containing a failed outcome with the provided failure details.
     pub fn failed(failure: TaskFailure) -> Self {
         Self {
             outcome: HostTaskOutcome::Failed(failure),
@@ -1755,7 +1758,7 @@ impl HostTaskResult {
     ///
     /// # Returns
     ///
-    /// A `HostTaskResult::Skipped` variant with default skip information (no reason or message).
+    /// A `HostTaskResult` containing a skipped outcome with default skip information.
     pub fn skipped() -> Self {
         Self {
             outcome: HostTaskOutcome::Skipped(TaskSkip::default()),
@@ -1776,7 +1779,7 @@ impl HostTaskResult {
     ///
     /// # Returns
     ///
-    /// A `HostTaskResult::Skipped` variant with the specified reason set.
+    /// A `HostTaskResult` containing a skipped outcome with the specified reason set.
     pub fn skipped_with_reason(reason: impl Into<String>) -> Self {
         Self {
             outcome: HostTaskOutcome::Skipped(TaskSkip::new().with_reason(reason)),
@@ -1822,18 +1825,31 @@ impl HostTaskResult {
         matches!(self.outcome, HostTaskOutcome::Skipped(_))
     }
 
+    /// Returns the semantic host outcome payload.
+    ///
+    /// Use this when you need to pattern match on the canonical passed/failed/skipped
+    /// variants directly.
     pub fn outcome(&self) -> &HostTaskOutcome {
         &self.outcome
     }
 
+    /// Returns execution metadata such as timing and retry attempt information.
+    ///
+    /// Host-level duration, timestamps, and retry counters live here rather than on
+    /// [`TaskSuccess`] or [`TaskFailure`].
     pub fn execution_metadata(&self) -> &HostExecutionMetadata {
         &self.execution_metadata
     }
 
+    /// Returns mutable access to the execution metadata.
     pub fn execution_metadata_mut(&mut self) -> &mut HostExecutionMetadata {
         &mut self.execution_metadata
     }
 
+    /// Returns a lowercase convenience status string.
+    ///
+    /// This compatibility accessor is useful for lightweight status checks where callers
+    /// do not need to pattern match on [`HostTaskOutcome`].
     pub fn status(&self) -> &'static str {
         match self.outcome() {
             HostTaskOutcome::Passed(_) => "passed",

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -195,6 +195,11 @@
 //! `connection_plugin_name()` directly, import [`TaskInfo`] so those trait methods
 //! are in scope.
 //!
+//! Static task metadata can also include retry overrides such as
+//! `allow_retries = true` and `max_task_attempts = 3`. These settings control
+//! retry policy only. A retry still requires the task to return a failed
+//! [`HostTaskResult`] whose [`TaskFailure`] is explicitly marked retryable.
+//!
 //! ```rust
 //! use genja_core::inventory::Host;
 //! use genja_core::task::{
@@ -208,7 +213,12 @@
 //!     config_file: String,
 //! }
 //!
-//! #[genja_task(name = "deploy", connection_plugin_name = "ssh")]
+//! #[genja_task(
+//!     name = "deploy",
+//!     connection_plugin_name = "ssh",
+//!     allow_retries = true,
+//!     max_task_attempts = 3
+//! )]
 //! impl DeployTask {
 //!     async fn start_async(
 //!         &self,
@@ -235,11 +245,12 @@
 //! ## [`TaskInfo`]
 //!
 //! Provides metadata about a task including its name, associated plugin, connection
-//! requirements, and optional configuration. This trait is typically
+//! requirements, retry overrides, and optional configuration. This trait is typically
 //! auto-implemented by the [`genja_task`](crate::genja_task) attribute macro.
 //! Static metadata comes from macro arguments such as `name`,
-//! `connection_plugin_name`, and `processors`, while dynamic metadata can be
-//! provided through helper methods such as `options()`.
+//! `connection_plugin_name`, `processors`, `allow_retries`, and
+//! `max_task_attempts`, while dynamic metadata can be provided through helper
+//! methods such as `options()`.
 //!
 //! ## Task Processors
 //!

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -647,7 +647,11 @@ impl EffectiveTaskRetryPolicy {
             .max(1);
 
         Self {
-            max_task_attempts: if allow_retries { configured_attempts } else { 1 },
+            max_task_attempts: if allow_retries {
+                configured_attempts
+            } else {
+                1
+            },
         }
     }
 
@@ -2195,7 +2199,6 @@ impl TaskSuccess {
     pub fn metadata(&self) -> Option<&Value> {
         self.metadata.as_ref()
     }
-
 }
 
 /// Represents a failed task execution with comprehensive error information and context.
@@ -2568,7 +2571,6 @@ impl TaskFailure {
     pub fn messages(&self) -> &[TaskMessage] {
         &self.messages
     }
-
 }
 
 /// Represents information about a skipped task execution.
@@ -3694,8 +3696,7 @@ impl TaskDefinition {
         if depth > max_depth {
             let started_at = SystemTime::now();
             let finished_at = started_at;
-            let error =
-                crate::GenjaError::Message(format!("max task depth exceeded: {max_depth}"));
+            let error = crate::GenjaError::Message(format!("max task depth exceeded: {max_depth}"));
             warn!(
                 "max task depth exceeded for task '{}' at depth {} with max_depth {}",
                 task.name(),
@@ -3757,7 +3758,8 @@ impl TaskDefinition {
                     let mut host_result = HostTaskResult::failed(
                         TaskFailure::new(error).with_kind(TaskFailureKind::Connection),
                     );
-                    host_result = host_result.with_execution_timing(started_at, finished_at, duration_ns);
+                    host_result =
+                        host_result.with_execution_timing(started_at, finished_at, duration_ns);
                     *host_result.execution_metadata_mut() = host_result
                         .execution_metadata()
                         .clone()
@@ -3864,7 +3866,8 @@ impl TaskDefinition {
         };
 
         let retry_exhausted = retry_policy.retry_exhausted(&host_result, attempts);
-        let mut host_result = host_result.with_execution_timing(started_at, finished_at, duration_ns);
+        let mut host_result =
+            host_result.with_execution_timing(started_at, finished_at, duration_ns);
         *host_result.execution_metadata_mut() = host_result
             .execution_metadata()
             .clone()
@@ -4562,7 +4565,12 @@ mod tests {
         assert!(host_result.execution_metadata().started_at().is_some());
         assert!(host_result.execution_metadata().finished_at().is_some());
         assert!(host_result.execution_metadata().duration_ns().is_some());
-        assert!(host_result.execution_metadata().duration_display().is_some());
+        assert!(
+            host_result
+                .execution_metadata()
+                .duration_display()
+                .is_some()
+        );
     }
 
     #[test]
@@ -4581,7 +4589,12 @@ mod tests {
         assert!(host_result.execution_metadata().started_at().is_some());
         assert!(host_result.execution_metadata().finished_at().is_some());
         assert!(host_result.execution_metadata().duration_ns().is_some());
-        assert!(host_result.execution_metadata().duration_display().is_some());
+        assert!(
+            host_result
+                .execution_metadata()
+                .duration_display()
+                .is_some()
+        );
     }
 
     #[test]
@@ -5089,10 +5102,7 @@ mod tests {
             .with_finished_at(finished_at)
             .with_duration_ns(250_000);
         results.insert_host_result("router2", failed);
-        results.insert_host_result(
-            "router3",
-            HostTaskResult::skipped_with_reason("filtered"),
-        );
+        results.insert_host_result("router3", HostTaskResult::skipped_with_reason("filtered"));
 
         let json = results
             .to_json_string()

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -3166,6 +3166,16 @@ pub trait TaskInfo {
     fn processor_names(&self) -> Vec<&str> {
         Vec::new()
     }
+
+    /// Returns whether retries are explicitly allowed for this task.
+    fn allow_retries(&self) -> Option<bool> {
+        None
+    }
+
+    /// Returns the maximum number of attempts explicitly configured for this task.
+    fn max_task_attempts(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Sub-task provider interface.
@@ -4160,6 +4170,14 @@ impl TaskInfo for TaskDefinition {
     fn processor_names(&self) -> Vec<&str> {
         self.processor_names()
     }
+
+    fn allow_retries(&self) -> Option<bool> {
+        self.inner.allow_retries()
+    }
+
+    fn max_task_attempts(&self) -> Option<usize> {
+        self.inner.max_task_attempts()
+    }
 }
 
 /// A collection of task definitions that can be executed together.
@@ -5108,15 +5126,16 @@ mod tests {
             .to_json_string()
             .expect("human json should serialize host timing");
 
-        assert!(json.contains("\"router1\":{\"Passed\":{"));
+        assert!(json.contains("\"router1\":{\"outcome\":{\"Passed\":{"));
         assert!(json.contains("\"summary\":\"ok\""));
         assert!(json.contains("\"started_at\":\"1970-01-01T00:00:00Z\""));
         assert!(json.contains("\"finished_at\":\"1970-01-01T00:00:00Z\""));
         assert!(json.contains("\"duration\":\"2ms\""));
-        assert!(json.contains("\"router2\":{\"Failed\":"));
+        assert!(json.contains("\"execution_metadata\":{\"started_at\":null,\"finished_at\":null,\"duration\":null,\"attempts\":1,\"retried\":false,\"retry_exhausted\":false}"));
+        assert!(json.contains("\"router2\":{\"outcome\":{\"Failed\":"));
         assert!(json.contains("\"duration\":\"250us\""));
-        assert!(json.contains("\"router3\":{\"Skipped\":{\"reason\":\"filtered\""));
-        assert!(!json.contains("\"router3\":{\"Skipped\":{\"started_at\""));
+        assert!(json.contains("\"router3\":{\"outcome\":{\"Skipped\":{\"reason\":\"filtered\""));
+        assert!(json.contains("\"router3\":{\"outcome\":{\"Skipped\":{\"reason\":\"filtered\",\"message\":null}},\"execution_metadata\":{\"started_at\":null,\"finished_at\":null,\"duration\":null,\"attempts\":1,\"retried\":false,\"retry_exhausted\":false}}"));
         assert!(!json.contains("\"duration_ns\""));
         assert!(!json.contains("\"duration_ms\""));
     }

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -932,9 +932,6 @@ struct TaskSuccessHumanJson<'a> {
     warnings: &'a [String],
     messages: &'a [TaskMessage],
     metadata: Option<&'a Value>,
-    started_at: Option<String>,
-    finished_at: Option<String>,
-    duration: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -946,9 +943,6 @@ struct TaskFailureHumanJson<'a> {
     details: Option<&'a Value>,
     warnings: &'a [String],
     messages: &'a [TaskMessage],
-    started_at: Option<String>,
-    finished_at: Option<String>,
-    duration: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -1074,9 +1068,6 @@ impl<'a> From<&'a TaskSuccess> for TaskSuccessHumanJson<'a> {
             warnings: success.warnings(),
             messages: success.messages(),
             metadata: success.metadata(),
-            started_at: success.started_at_display(),
-            finished_at: success.finished_at_display(),
-            duration: success.duration_display(),
         }
     }
 }
@@ -1091,9 +1082,6 @@ impl<'a> From<&'a TaskFailure> for TaskFailureHumanJson<'a> {
             details: failure.details(),
             warnings: failure.warnings(),
             messages: failure.messages(),
-            started_at: failure.started_at_display(),
-            finished_at: failure.finished_at_display(),
-            duration: failure.duration_display(),
         }
     }
 }
@@ -5359,25 +5347,22 @@ mod tests {
             .checked_add(std::time::Duration::from_millis(2))
             .expect("valid timestamp");
         let mut results = TaskResults::new("deploy");
-        results.insert_host_result(
-            "router1",
-            HostTaskResult::passed(
-                TaskSuccess::new()
-                    .with_summary("ok")
-                    .with_started_at(started_at)
-                    .with_finished_at(finished_at)
-                    .with_duration_ns(2_000_000),
-            ),
-        );
-        results.insert_host_result(
-            "router2",
-            HostTaskResult::failed(
-                TaskFailure::new(TestTaskFailureError)
-                    .with_started_at(started_at)
-                    .with_finished_at(finished_at)
-                    .with_duration_ns(250_000),
-            ),
-        );
+        let mut passed = HostTaskResult::passed(TaskSuccess::new().with_summary("ok"));
+        *passed.execution_metadata_mut() = passed
+            .execution_metadata()
+            .clone()
+            .with_started_at(started_at)
+            .with_finished_at(finished_at)
+            .with_duration_ns(2_000_000);
+        results.insert_host_result("router1", passed);
+        let mut failed = HostTaskResult::failed(TaskFailure::new(TestTaskFailureError));
+        *failed.execution_metadata_mut() = failed
+            .execution_metadata()
+            .clone()
+            .with_started_at(started_at)
+            .with_finished_at(finished_at)
+            .with_duration_ns(250_000);
+        results.insert_host_result("router2", failed);
         results.insert_host_result(
             "router3",
             HostTaskResult::skipped_with_reason("filtered"),
@@ -5389,14 +5374,13 @@ mod tests {
 
         assert!(json.contains("\"router1\":{\"outcome\":{\"Passed\":{"));
         assert!(json.contains("\"summary\":\"ok\""));
-        assert!(json.contains("\"started_at\":\"1970-01-01T00:00:00Z\""));
-        assert!(json.contains("\"finished_at\":\"1970-01-01T00:00:00Z\""));
-        assert!(json.contains("\"duration\":\"2ms\""));
-        assert!(json.contains("\"execution_metadata\":{\"started_at\":null,\"finished_at\":null,\"duration\":null,\"attempts\":1,\"retried\":false,\"retry_exhausted\":false}"));
+        assert!(json.contains("\"execution_metadata\":{\"started_at\":\"1970-01-01T00:00:00Z\",\"finished_at\":\"1970-01-01T00:00:00Z\",\"duration\":\"2ms\",\"attempts\":1,\"retried\":false,\"retry_exhausted\":false}"));
         assert!(json.contains("\"router2\":{\"outcome\":{\"Failed\":"));
-        assert!(json.contains("\"duration\":\"250us\""));
+        assert!(json.contains("\"execution_metadata\":{\"started_at\":\"1970-01-01T00:00:00Z\",\"finished_at\":\"1970-01-01T00:00:00Z\",\"duration\":\"250us\",\"attempts\":1,\"retried\":false,\"retry_exhausted\":false}"));
         assert!(json.contains("\"router3\":{\"outcome\":{\"Skipped\":{\"reason\":\"filtered\""));
         assert!(json.contains("\"router3\":{\"outcome\":{\"Skipped\":{\"reason\":\"filtered\",\"message\":null}},\"execution_metadata\":{\"started_at\":null,\"finished_at\":null,\"duration\":null,\"attempts\":1,\"retried\":false,\"retry_exhausted\":false}}"));
+        assert!(!json.contains("\"Passed\":{\"result\":null,\"changed\":false,\"diff\":null,\"summary\":\"ok\",\"warnings\":[],\"messages\":[],\"metadata\":null,\"started_at\""));
+        assert!(!json.contains("\"Failed\":{\"kind\":\"Internal\",\"error_type\":\"genja_core::task::tests::TestTaskFailureError\",\"message\":\"task failure test error\",\"retryable\":false,\"details\":null,\"warnings\":[],\"messages\":[],\"started_at\""));
         assert!(!json.contains("\"duration_ns\""));
         assert!(!json.contains("\"duration_ms\""));
     }

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -842,10 +842,26 @@ struct TaskResultsHumanJson<'a> {
 }
 
 #[derive(Serialize)]
-enum HostTaskResultHumanJson<'a> {
+struct HostTaskResultHumanJson<'a> {
+    outcome: HostTaskOutcomeHumanJson<'a>,
+    execution_metadata: HostExecutionMetadataHumanJson,
+}
+
+#[derive(Serialize)]
+enum HostTaskOutcomeHumanJson<'a> {
     Passed(TaskSuccessHumanJson<'a>),
     Failed(TaskFailureHumanJson<'a>),
     Skipped(TaskSkipHumanJson<'a>),
+}
+
+#[derive(Serialize)]
+struct HostExecutionMetadataHumanJson {
+    started_at: Option<String>,
+    finished_at: Option<String>,
+    duration: Option<String>,
+    attempts: usize,
+    retried: bool,
+    retry_exhausted: bool,
 }
 
 #[derive(Serialize)]
@@ -959,10 +975,32 @@ impl TaskResultsSummary {
 
 impl<'a> From<&'a HostTaskResult> for HostTaskResultHumanJson<'a> {
     fn from(result: &'a HostTaskResult) -> Self {
+        Self {
+            outcome: HostTaskOutcomeHumanJson::from(result.outcome()),
+            execution_metadata: HostExecutionMetadataHumanJson::from(result.execution_metadata()),
+        }
+    }
+}
+
+impl<'a> From<&'a HostTaskOutcome> for HostTaskOutcomeHumanJson<'a> {
+    fn from(result: &'a HostTaskOutcome) -> Self {
         match result {
-            HostTaskResult::Passed(success) => Self::Passed(TaskSuccessHumanJson::from(success)),
-            HostTaskResult::Failed(failure) => Self::Failed(TaskFailureHumanJson::from(failure)),
-            HostTaskResult::Skipped(skip) => Self::Skipped(TaskSkipHumanJson::from(skip)),
+            HostTaskOutcome::Passed(success) => Self::Passed(TaskSuccessHumanJson::from(success)),
+            HostTaskOutcome::Failed(failure) => Self::Failed(TaskFailureHumanJson::from(failure)),
+            HostTaskOutcome::Skipped(skip) => Self::Skipped(TaskSkipHumanJson::from(skip)),
+        }
+    }
+}
+
+impl From<&HostExecutionMetadata> for HostExecutionMetadataHumanJson {
+    fn from(metadata: &HostExecutionMetadata) -> Self {
+        Self {
+            started_at: metadata.started_at_display(),
+            finished_at: metadata.finished_at_display(),
+            duration: metadata.duration_display(),
+            attempts: metadata.attempts(),
+            retried: metadata.retried(),
+            retry_exhausted: metadata.retry_exhausted(),
         }
     }
 }
@@ -1503,10 +1541,123 @@ impl TaskResults {
 /// assert!(skipped.is_skipped());
 /// ```
 #[derive(Debug, Clone, Serialize)]
-pub enum HostTaskResult {
+pub struct HostTaskResult {
+    outcome: HostTaskOutcome,
+    execution_metadata: HostExecutionMetadata,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum HostTaskOutcome {
     Passed(TaskSuccess),
     Failed(TaskFailure),
     Skipped(TaskSkip),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostExecutionMetadata {
+    started_at: Option<SystemTime>,
+    finished_at: Option<SystemTime>,
+    duration_ns: Option<u128>,
+    duration_ms: Option<u128>,
+    attempts: usize,
+    retried: bool,
+    retry_exhausted: bool,
+}
+
+impl Default for HostExecutionMetadata {
+    fn default() -> Self {
+        Self {
+            started_at: None,
+            finished_at: None,
+            duration_ns: None,
+            duration_ms: None,
+            attempts: 1,
+            retried: false,
+            retry_exhausted: false,
+        }
+    }
+}
+
+impl HostExecutionMetadata {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_started_at(mut self, started_at: SystemTime) -> Self {
+        self.started_at = Some(started_at);
+        self
+    }
+
+    pub fn with_finished_at(mut self, finished_at: SystemTime) -> Self {
+        self.finished_at = Some(finished_at);
+        self
+    }
+
+    pub fn with_duration_ns(mut self, duration_ns: u128) -> Self {
+        self.duration_ns = Some(duration_ns);
+        self.duration_ms = Some(duration_ns / 1_000_000);
+        self
+    }
+
+    pub fn with_attempts(mut self, attempts: usize) -> Self {
+        self.attempts = attempts;
+        self
+    }
+
+    pub fn with_retried(mut self, retried: bool) -> Self {
+        self.retried = retried;
+        self
+    }
+
+    pub fn with_retry_exhausted(mut self, retry_exhausted: bool) -> Self {
+        self.retry_exhausted = retry_exhausted;
+        self
+    }
+
+    pub fn started_at(&self) -> Option<SystemTime> {
+        self.started_at
+    }
+
+    pub fn finished_at(&self) -> Option<SystemTime> {
+        self.finished_at
+    }
+
+    pub fn duration_ns(&self) -> Option<u128> {
+        self.duration_ns.or_else(|| {
+            self.duration_ms
+                .map(|duration_ms| duration_ms.saturating_mul(1_000_000))
+        })
+    }
+
+    pub fn duration_ms(&self) -> Option<u128> {
+        self.duration_ns
+            .map(|duration_ns| duration_ns / 1_000_000)
+            .or(self.duration_ms)
+    }
+
+    pub fn attempts(&self) -> usize {
+        self.attempts
+    }
+
+    pub fn retried(&self) -> bool {
+        self.retried
+    }
+
+    pub fn retry_exhausted(&self) -> bool {
+        self.retry_exhausted
+    }
+
+    pub fn started_at_display(&self) -> Option<String> {
+        self.started_at.map(format_timestamp_display)
+    }
+
+    pub fn finished_at_display(&self) -> Option<String> {
+        self.finished_at.map(format_timestamp_display)
+    }
+
+    pub fn duration_display(&self) -> Option<String> {
+        self.duration_ns().map(format_duration_display)
+    }
 }
 
 impl HostTaskResult {
@@ -1524,7 +1675,10 @@ impl HostTaskResult {
     ///
     /// A `HostTaskResult::Passed` variant containing the provided success details.
     pub fn passed(result: TaskSuccess) -> Self {
-        Self::Passed(result)
+        Self {
+            outcome: HostTaskOutcome::Passed(result),
+            execution_metadata: HostExecutionMetadata::new(),
+        }
     }
 
     /// Creates a new `HostTaskResult` representing a failed task execution.
@@ -1541,7 +1695,10 @@ impl HostTaskResult {
     ///
     /// A `HostTaskResult::Failed` variant containing the provided failure details.
     pub fn failed(failure: TaskFailure) -> Self {
-        Self::Failed(failure)
+        Self {
+            outcome: HostTaskOutcome::Failed(failure),
+            execution_metadata: HostExecutionMetadata::new(),
+        }
     }
 
     /// Creates a new `HostTaskResult` representing a skipped task execution.
@@ -1553,7 +1710,10 @@ impl HostTaskResult {
     ///
     /// A `HostTaskResult::Skipped` variant with default skip information (no reason or message).
     pub fn skipped() -> Self {
-        Self::Skipped(TaskSkip::default())
+        Self {
+            outcome: HostTaskOutcome::Skipped(TaskSkip::default()),
+            execution_metadata: HostExecutionMetadata::new(),
+        }
     }
 
     /// Creates a new `HostTaskResult` representing a skipped task execution with a reason.
@@ -1571,7 +1731,18 @@ impl HostTaskResult {
     ///
     /// A `HostTaskResult::Skipped` variant with the specified reason set.
     pub fn skipped_with_reason(reason: impl Into<String>) -> Self {
-        Self::Skipped(TaskSkip::new().with_reason(reason))
+        Self {
+            outcome: HostTaskOutcome::Skipped(TaskSkip::new().with_reason(reason)),
+            execution_metadata: HostExecutionMetadata::new(),
+        }
+    }
+
+    /// Creates a skipped host result from an explicit skip payload.
+    pub fn skipped_with_detail(skip: TaskSkip) -> Self {
+        Self {
+            outcome: HostTaskOutcome::Skipped(skip),
+            execution_metadata: HostExecutionMetadata::new(),
+        }
     }
 
     /// Checks if the task execution passed (completed successfully).
@@ -1581,7 +1752,7 @@ impl HostTaskResult {
     /// `true` if this result represents a successful task execution (`Passed` variant),
     /// `false` otherwise.
     pub fn is_passed(&self) -> bool {
-        matches!(self, Self::Passed(_))
+        matches!(self.outcome, HostTaskOutcome::Passed(_))
     }
 
     /// Checks if the task execution failed.
@@ -1591,7 +1762,7 @@ impl HostTaskResult {
     /// `true` if this result represents a failed task execution (`Failed` variant),
     /// `false` otherwise.
     pub fn is_failed(&self) -> bool {
-        matches!(self, Self::Failed(_))
+        matches!(self.outcome, HostTaskOutcome::Failed(_))
     }
 
     /// Checks if the task execution was skipped.
@@ -1601,7 +1772,27 @@ impl HostTaskResult {
     /// `true` if this result represents a skipped task execution (`Skipped` variant),
     /// `false` otherwise.
     pub fn is_skipped(&self) -> bool {
-        matches!(self, Self::Skipped(_))
+        matches!(self.outcome, HostTaskOutcome::Skipped(_))
+    }
+
+    pub fn outcome(&self) -> &HostTaskOutcome {
+        &self.outcome
+    }
+
+    pub fn execution_metadata(&self) -> &HostExecutionMetadata {
+        &self.execution_metadata
+    }
+
+    pub fn execution_metadata_mut(&mut self) -> &mut HostExecutionMetadata {
+        &mut self.execution_metadata
+    }
+
+    pub fn status(&self) -> &'static str {
+        match self.outcome() {
+            HostTaskOutcome::Passed(_) => "passed",
+            HostTaskOutcome::Failed(_) => "failed",
+            HostTaskOutcome::Skipped(_) => "skipped",
+        }
     }
 
     /// Retrieves the success details if the task passed.
@@ -1614,9 +1805,9 @@ impl HostTaskResult {
     /// `Some(&TaskSuccess)` if this is a `Passed` result, `None` if the task failed
     /// or was skipped.
     pub fn success(&self) -> Option<&TaskSuccess> {
-        match self {
-            Self::Passed(success) => Some(success),
-            Self::Failed(_) | Self::Skipped(_) => None,
+        match self.outcome() {
+            HostTaskOutcome::Passed(success) => Some(success),
+            HostTaskOutcome::Failed(_) | HostTaskOutcome::Skipped(_) => None,
         }
     }
 
@@ -1630,9 +1821,9 @@ impl HostTaskResult {
     /// `Some(&TaskFailure)` if this is a `Failed` result, `None` if the task passed
     /// or was skipped.
     pub fn failure(&self) -> Option<&TaskFailure> {
-        match self {
-            Self::Failed(failure) => Some(failure),
-            Self::Passed(_) | Self::Skipped(_) => None,
+        match self.outcome() {
+            HostTaskOutcome::Failed(failure) => Some(failure),
+            HostTaskOutcome::Passed(_) | HostTaskOutcome::Skipped(_) => None,
         }
     }
 
@@ -1646,9 +1837,9 @@ impl HostTaskResult {
     /// `Some(&TaskSkip)` if this is a `Skipped` result, `None` if the task passed
     /// or failed.
     pub fn skipped_detail(&self) -> Option<&TaskSkip> {
-        match self {
-            Self::Skipped(skip) => Some(skip),
-            Self::Passed(_) | Self::Failed(_) => None,
+        match self.outcome() {
+            HostTaskOutcome::Skipped(skip) => Some(skip),
+            HostTaskOutcome::Passed(_) | HostTaskOutcome::Failed(_) => None,
         }
     }
 
@@ -1658,20 +1849,30 @@ impl HostTaskResult {
         finished_at: SystemTime,
         duration_ns: u128,
     ) -> Self {
-        match self {
-            Self::Passed(success) => Self::Passed(
+        let execution_metadata = self
+            .execution_metadata
+            .clone()
+            .with_started_at(started_at)
+            .with_finished_at(finished_at)
+            .with_duration_ns(duration_ns);
+        let outcome = match self.outcome {
+            HostTaskOutcome::Passed(success) => HostTaskOutcome::Passed(
                 success
                     .with_started_at(started_at)
                     .with_finished_at(finished_at)
                     .with_duration_ns(duration_ns),
             ),
-            Self::Failed(failure) => Self::Failed(
+            HostTaskOutcome::Failed(failure) => HostTaskOutcome::Failed(
                 failure
                     .with_started_at(started_at)
                     .with_finished_at(finished_at)
                     .with_duration_ns(duration_ns),
             ),
-            Self::Skipped(skip) => Self::Skipped(skip),
+            HostTaskOutcome::Skipped(skip) => HostTaskOutcome::Skipped(skip),
+        };
+        Self {
+            outcome,
+            execution_metadata,
         }
     }
 }
@@ -3820,14 +4021,14 @@ impl TaskDefinition {
 
         let mut host_result =
             host_result.with_execution_timing(started_at, finished_at, duration_ns);
-        let duration_display = match &host_result {
-            HostTaskResult::Passed(success) => success
+        let duration_display = match host_result.outcome() {
+            HostTaskOutcome::Passed(success) => success
                 .duration_display()
                 .unwrap_or_else(|| format_duration_display(duration_ns)),
-            HostTaskResult::Failed(failure) => failure
+            HostTaskOutcome::Failed(failure) => failure
                 .duration_display()
                 .unwrap_or_else(|| format_duration_display(duration_ns)),
-            HostTaskResult::Skipped(_) => format_duration_display(duration_ns),
+            HostTaskOutcome::Skipped(_) => format_duration_display(duration_ns),
         };
 
         info!(
@@ -4283,9 +4484,7 @@ mod tests {
             _host: &Host,
             _context: &TaskRuntimeContext,
         ) -> Result<HostTaskResult, TaskError> {
-            Ok(HostTaskResult::Skipped(
-                TaskSkip::new().with_reason("filtered"),
-            ))
+            Ok(HostTaskResult::skipped_with_reason("filtered"))
         }
 
         fn execution_mode(&self) -> TaskExecutionMode {
@@ -4718,11 +4917,14 @@ mod tests {
 
     #[test]
     fn task_skip_and_host_task_result_expose_skip_metadata() {
-        let skipped = HostTaskResult::Skipped(
-            TaskSkip::new()
-                .with_reason("filtered")
-                .with_message("host excluded by selector"),
-        );
+        let skipped = HostTaskResult {
+            outcome: HostTaskOutcome::Skipped(
+                TaskSkip::new()
+                    .with_reason("filtered")
+                    .with_message("host excluded by selector"),
+            ),
+            execution_metadata: HostExecutionMetadata::new(),
+        };
 
         assert!(skipped.is_skipped());
         assert_eq!(
@@ -4899,7 +5101,7 @@ mod tests {
         );
         results.insert_host_result(
             "router3",
-            HostTaskResult::Skipped(TaskSkip::new().with_reason("filtered")),
+            HostTaskResult::skipped_with_reason("filtered"),
         );
 
         let json = results
@@ -5006,11 +5208,14 @@ mod tests {
         );
         validate.insert_host_result(
             "router2",
-            HostTaskResult::Skipped(
-                TaskSkip::new()
-                    .with_reason("parent_failed")
-                    .with_message("validation skipped because deploy failed"),
-            ),
+            HostTaskResult {
+                outcome: HostTaskOutcome::Skipped(
+                    TaskSkip::new()
+                        .with_reason("parent_failed")
+                        .with_message("validation skipped because deploy failed"),
+                ),
+                execution_metadata: HostExecutionMetadata::new(),
+            },
         );
 
         let mut collect_logs = TaskResults::new("collect_logs");

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -580,6 +580,7 @@
 //! Tasks can define sub-tasks that execute after the parent task completes. This
 //!
 use crate::inventory::{Connection, Host};
+use crate::settings::RunnerConfig;
 use crate::types::{CustomTreeMap, NatString};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
@@ -595,6 +596,64 @@ use std::time::SystemTime;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 use tokio::task;
+
+#[derive(Debug, Clone, Copy)]
+struct TaskRetryDefaults {
+    allow_retries: bool,
+    max_task_attempts: usize,
+}
+
+impl Default for TaskRetryDefaults {
+    fn default() -> Self {
+        Self {
+            allow_retries: false,
+            max_task_attempts: 1,
+        }
+    }
+}
+
+impl From<&RunnerConfig> for TaskRetryDefaults {
+    fn from(runner_config: &RunnerConfig) -> Self {
+        Self {
+            allow_retries: runner_config.allow_retries(),
+            max_task_attempts: runner_config.max_task_attempts().max(1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EffectiveTaskRetryPolicy {
+    max_task_attempts: usize,
+}
+
+impl EffectiveTaskRetryPolicy {
+    fn for_task(task: &dyn Task, defaults: TaskRetryDefaults) -> Self {
+        let allow_retries = task.allow_retries().unwrap_or(defaults.allow_retries);
+        let configured_attempts = task
+            .max_task_attempts()
+            .unwrap_or(defaults.max_task_attempts)
+            .max(1);
+
+        Self {
+            max_task_attempts: if allow_retries { configured_attempts } else { 1 },
+        }
+    }
+
+    fn max_task_attempts(&self) -> usize {
+        self.max_task_attempts
+    }
+
+    fn should_retry(&self, result: &HostTaskResult, attempts: usize) -> bool {
+        attempts < self.max_task_attempts
+            && matches!(result.failure(), Some(failure) if failure.retryable())
+    }
+
+    fn retry_exhausted(&self, result: &HostTaskResult, attempts: usize) -> bool {
+        attempts >= self.max_task_attempts
+            && self.max_task_attempts > 1
+            && matches!(result.failure(), Some(failure) if failure.retryable())
+    }
+}
 
 /// Represents an error that occurred during task execution.
 ///
@@ -3739,17 +3798,14 @@ impl TaskDefinition {
         results: &mut TaskResults,
         max_depth: usize,
     ) -> Result<(), crate::GenjaError> {
-        Self::start_with_depth(
+        self.start_with_retry_defaults(
             Arc::clone(&self.inner),
             hostname,
             host,
             results,
             None,
-            self.processor_resolver.as_deref(),
-            self.processor_names(),
-            None,
-            0,
             max_depth,
+            TaskRetryDefaults::default(),
         )
         .await
     }
@@ -3763,8 +3819,52 @@ impl TaskDefinition {
         connection_resolver: Option<&dyn TaskConnectionResolver>,
         max_depth: usize,
     ) -> Result<(), crate::GenjaError> {
-        Self::start_with_depth(
+        self.start_with_retry_defaults(
             Arc::clone(&self.inner),
+            hostname,
+            host,
+            results,
+            connection_resolver,
+            max_depth,
+            TaskRetryDefaults::default(),
+        )
+        .await
+    }
+
+    /// Executes this task definition with runner-supplied retry defaults.
+    pub async fn start_with_connection_resolver_and_runner_config(
+        &self,
+        hostname: &str,
+        host: &Host,
+        results: &mut TaskResults,
+        connection_resolver: Option<&dyn TaskConnectionResolver>,
+        runner_config: &RunnerConfig,
+        max_depth: usize,
+    ) -> Result<(), crate::GenjaError> {
+        self.start_with_retry_defaults(
+            Arc::clone(&self.inner),
+            hostname,
+            host,
+            results,
+            connection_resolver,
+            max_depth,
+            TaskRetryDefaults::from(runner_config),
+        )
+        .await
+    }
+
+    async fn start_with_retry_defaults(
+        &self,
+        task: Arc<dyn Task>,
+        hostname: &str,
+        host: &Host,
+        results: &mut TaskResults,
+        connection_resolver: Option<&dyn TaskConnectionResolver>,
+        max_depth: usize,
+        retry_defaults: TaskRetryDefaults,
+    ) -> Result<(), crate::GenjaError> {
+        Self::start_with_depth(
+            task,
             hostname,
             host,
             results,
@@ -3774,6 +3874,7 @@ impl TaskDefinition {
             None,
             0,
             max_depth,
+            retry_defaults,
         )
         .await
     }
@@ -3856,6 +3957,7 @@ impl TaskDefinition {
         parent_task_name: Option<&str>,
         depth: usize,
         max_depth: usize,
+        retry_defaults: TaskRetryDefaults,
     ) -> Result<(), crate::GenjaError> {
         if depth > max_depth {
             let started_at = SystemTime::now();
@@ -3869,16 +3971,21 @@ impl TaskDefinition {
                 max_depth
             );
             results.record_execution_timing(started_at, finished_at);
-            results.insert_host_result(
-                hostname,
-                HostTaskResult::failed(
-                    TaskFailure::new(error)
-                        .with_kind(TaskFailureKind::Internal)
-                        .with_started_at(started_at)
-                        .with_finished_at(finished_at)
-                        .with_duration_ns(0),
-                ),
-            );
+            let mut host_result = HostTaskResult::failed(
+                TaskFailure::new(error)
+                    .with_kind(TaskFailureKind::Internal)
+                    .with_started_at(started_at)
+                    .with_finished_at(finished_at)
+                    .with_duration_ns(0),
+            )
+            .with_execution_timing(started_at, finished_at, 0);
+            *host_result.execution_metadata_mut() = host_result
+                .execution_metadata()
+                .clone()
+                .with_attempts(1)
+                .with_retried(false)
+                .with_retry_exhausted(false);
+            results.insert_host_result(hostname, host_result);
             return Ok(());
         }
 
@@ -3893,12 +4000,10 @@ impl TaskDefinition {
             max_depth,
             connection_resolver.is_some()
         );
+        let retry_policy = EffectiveTaskRetryPolicy::for_task(task.as_ref(), retry_defaults);
         let processor_context =
             TaskProcessorContext::new(task.name(), parent_task_name, depth, Some(hostname));
         let processors = Self::resolve_processors(processor_resolver, &processor_names)?;
-        for processor in &processors {
-            processor.on_instance_start(&processor_context)?;
-        }
 
         let connection = if let Some(connection_resolver) = connection_resolver {
             match connection_resolver
@@ -3923,11 +4028,18 @@ impl TaskDefinition {
 
                     let mut host_result = HostTaskResult::failed(
                         TaskFailure::new(error)
-                            .with_kind(TaskFailureKind::Connection)
-                            .with_started_at(started_at)
-                            .with_finished_at(finished_at)
-                            .with_duration_ns(duration_ns),
+                        .with_kind(TaskFailureKind::Connection)
+                        .with_started_at(started_at)
+                        .with_finished_at(finished_at)
+                        .with_duration_ns(duration_ns),
                     );
+                    host_result = host_result.with_execution_timing(started_at, finished_at, duration_ns);
+                    *host_result.execution_metadata_mut() = host_result
+                        .execution_metadata()
+                        .clone()
+                        .with_attempts(1)
+                        .with_retried(false)
+                        .with_retry_exhausted(false);
                     for processor in &processors {
                         processor.on_instance_finish(&processor_context, &mut host_result)?;
                     }
@@ -3939,29 +4051,59 @@ impl TaskDefinition {
             None
         };
 
-        let execution_context = TaskExecutionContext::new(depth, max_depth);
-        let host_result = match task.execution_mode() {
-            TaskExecutionMode::Async => {
-                let runtime_context =
-                    TaskRuntimeContext::new(execution_context, connection.clone());
-                task.start_async(host, &runtime_context).await
+        let mut attempts = 0;
+        let host_result = loop {
+            attempts += 1;
+            for processor in &processors {
+                processor.on_instance_start(&processor_context)?;
             }
-            TaskExecutionMode::Blocking => {
-                let blocking_context = BlockingTaskRuntimeContext::new(
-                    execution_context,
-                    connection.clone(),
-                    Handle::current(),
-                );
-                let task = Arc::clone(&task);
-                let host = host.clone();
-                match task::spawn_blocking(move || task.start(&host, &blocking_context)).await {
-                    Ok(result) => result,
-                    Err(err) => Err(TaskError::new(std::io::Error::other(format!(
-                        "blocking task join error: {err}"
-                    )))),
+
+            let execution_context = TaskExecutionContext::new(depth, max_depth);
+            let host_result = match task.execution_mode() {
+                TaskExecutionMode::Async => {
+                    let runtime_context =
+                        TaskRuntimeContext::new(execution_context, connection.clone());
+                    task.start_async(host, &runtime_context).await
                 }
+                TaskExecutionMode::Blocking => {
+                    let blocking_context = BlockingTaskRuntimeContext::new(
+                        execution_context,
+                        connection.clone(),
+                        Handle::current(),
+                    );
+                    let task = Arc::clone(&task);
+                    let host = host.clone();
+                    match task::spawn_blocking(move || task.start(&host, &blocking_context)).await {
+                        Ok(result) => result,
+                        Err(err) => Err(TaskError::new(std::io::Error::other(format!(
+                            "blocking task join error: {err}"
+                        )))),
+                    }
+                }
+            };
+
+            let host_result = match host_result {
+                Ok(host_result) => host_result,
+                Err(error) => HostTaskResult::failed(TaskFailure::from_task_error(error)),
+            };
+
+            if retry_policy.should_retry(&host_result, attempts) {
+                if let Some(failure) = host_result.failure() {
+                    warn!(
+                        "retrying task '{}' for host '{}' after attempt {}/{}: {}",
+                        task.name(),
+                        hostname,
+                        attempts,
+                        retry_policy.max_task_attempts(),
+                        failure.message()
+                    );
+                }
+                continue;
             }
+
+            break host_result;
         };
+
         let finished_at = SystemTime::now();
         let duration_ns = finished_at
             .duration_since(started_at)
@@ -3969,38 +4111,6 @@ impl TaskDefinition {
             .unwrap_or(0);
 
         results.record_execution_timing(started_at, finished_at);
-
-        let host_result = match host_result {
-            Ok(host_result) => host_result,
-            Err(error) => {
-                let failure = TaskFailure::from_task_error(error)
-                    .with_started_at(started_at)
-                    .with_finished_at(finished_at)
-                    .with_duration_ns(duration_ns);
-                warn!(
-                    "task '{}' failed for host '{}': {}",
-                    task.name(),
-                    hostname,
-                    failure.message()
-                );
-                let duration_display = failure
-                    .duration_display()
-                    .unwrap_or_else(|| format_duration_display(duration_ns));
-                info!(
-                    "finished task '{}' for host '{}' with status=failed duration_ms={} duration={}",
-                    task.name(),
-                    hostname,
-                    duration_ns / 1_000_000,
-                    duration_display
-                );
-                let mut host_result = HostTaskResult::failed(failure);
-                for processor in &processors {
-                    processor.on_instance_finish(&processor_context, &mut host_result)?;
-                }
-                results.insert_host_result(hostname, host_result);
-                return Ok(());
-            }
-        };
 
         if let Some(failure) = host_result.failure() {
             warn!(
@@ -4029,8 +4139,14 @@ impl TaskDefinition {
             "skipped"
         };
 
-        let mut host_result =
-            host_result.with_execution_timing(started_at, finished_at, duration_ns);
+        let retry_exhausted = retry_policy.retry_exhausted(&host_result, attempts);
+        let mut host_result = host_result.with_execution_timing(started_at, finished_at, duration_ns);
+        *host_result.execution_metadata_mut() = host_result
+            .execution_metadata()
+            .clone()
+            .with_attempts(attempts)
+            .with_retried(attempts > 1)
+            .with_retry_exhausted(retry_exhausted);
         let duration_display = match host_result.outcome() {
             HostTaskOutcome::Passed(success) => success
                 .duration_display()
@@ -4093,6 +4209,7 @@ impl TaskDefinition {
                 Some(task.name()),
                 depth + 1,
                 max_depth,
+                retry_defaults,
             )
             .await?;
             if sub_task_started {
@@ -4310,6 +4427,12 @@ mod tests {
 
     struct SkippingTask;
 
+    struct FlakyTask {
+        name: &'static str,
+        attempts: Arc<AtomicUsize>,
+        succeed_on_attempt: usize,
+    }
+
     #[derive(Debug)]
     struct TestConnection {
         key: ConnectionKey,
@@ -4503,6 +4626,50 @@ mod tests {
             _context: &TaskRuntimeContext,
         ) -> Result<HostTaskResult, TaskError> {
             Ok(HostTaskResult::skipped_with_reason("filtered"))
+        }
+
+        fn execution_mode(&self) -> TaskExecutionMode {
+            TaskExecutionMode::Async
+        }
+    }
+
+    impl TaskInfo for FlakyTask {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn connection_plugin_name(&self) -> Option<&str> {
+            Some("ssh")
+        }
+
+        fn options(&self) -> Option<&Value> {
+            None
+        }
+    }
+
+    #[async_trait]
+    impl Task for FlakyTask {
+        async fn start_async(
+            &self,
+            _host: &Host,
+            _context: &TaskRuntimeContext,
+        ) -> Result<HostTaskResult, TaskError> {
+            let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            if attempt >= self.succeed_on_attempt {
+                Ok(HostTaskResult::passed(
+                    TaskSuccess::new().with_summary(format!("passed on attempt {attempt}")),
+                ))
+            } else {
+                Ok(HostTaskResult::failed(
+                    TaskFailure::new(TestTaskFailureError)
+                        .with_kind(TaskFailureKind::Connection)
+                        .with_retryable(true)
+                        .with_message(TaskMessage::new(
+                            MessageLevel::Warning,
+                            format!("attempt {attempt} failed"),
+                        )),
+                ))
+            }
         }
 
         fn execution_mode(&self) -> TaskExecutionMode {
@@ -4708,6 +4875,100 @@ mod tests {
             .expect("host result should be skipped");
         assert_eq!(skip.reason(), Some("filtered"));
         assert_eq!(skip.message(), None);
+    }
+
+    #[test]
+    fn start_retries_retryable_failures_when_enabled_by_runner_config() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let task = TaskDefinition::new(FlakyTask {
+            name: "flaky",
+            attempts: Arc::clone(&attempts),
+            succeed_on_attempt: 2,
+        });
+        let runner_config = RunnerConfig::builder()
+            .allow_retries(true)
+            .max_task_attempts(3)
+            .build();
+        let host = Host::builder().hostname("router1").build();
+        let mut results = TaskResults::new("flaky");
+
+        run_async(task.start_with_connection_resolver_and_runner_config(
+            "router1",
+            &host,
+            &mut results,
+            None,
+            &runner_config,
+            0,
+        ))
+        .expect("start should succeed after retry");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        let host_result = results
+            .host_result("router1")
+            .expect("host result should exist");
+        assert!(host_result.is_passed());
+        assert_eq!(host_result.execution_metadata().attempts(), 2);
+        assert!(host_result.execution_metadata().retried());
+        assert!(!host_result.execution_metadata().retry_exhausted());
+    }
+
+    #[test]
+    fn start_marks_retry_exhausted_after_final_retryable_failure() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let task = TaskDefinition::new(FlakyTask {
+            name: "always_fails",
+            attempts: Arc::clone(&attempts),
+            succeed_on_attempt: usize::MAX,
+        });
+        let runner_config = RunnerConfig::builder()
+            .allow_retries(true)
+            .max_task_attempts(3)
+            .build();
+        let host = Host::builder().hostname("router1").build();
+        let mut results = TaskResults::new("always_fails");
+
+        run_async(task.start_with_connection_resolver_and_runner_config(
+            "router1",
+            &host,
+            &mut results,
+            None,
+            &runner_config,
+            0,
+        ))
+        .expect("start should capture exhausted retries");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        let host_result = results
+            .host_result("router1")
+            .expect("host result should exist");
+        assert!(host_result.is_failed());
+        assert_eq!(host_result.execution_metadata().attempts(), 3);
+        assert!(host_result.execution_metadata().retried());
+        assert!(host_result.execution_metadata().retry_exhausted());
+    }
+
+    #[test]
+    fn start_does_not_retry_without_effective_retry_policy() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let task = TaskDefinition::new(FlakyTask {
+            name: "no_retry",
+            attempts: Arc::clone(&attempts),
+            succeed_on_attempt: 2,
+        });
+        let host = Host::builder().hostname("router1").build();
+        let mut results = TaskResults::new("no_retry");
+
+        run_async(task.start("router1", &host, &mut results, 0))
+            .expect("start should record first failure without retry");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        let host_result = results
+            .host_result("router1")
+            .expect("host result should exist");
+        assert!(host_result.is_failed());
+        assert_eq!(host_result.execution_metadata().attempts(), 1);
+        assert!(!host_result.execution_metadata().retried());
+        assert!(!host_result.execution_metadata().retry_exhausted());
     }
 
     #[test]

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -3535,7 +3535,6 @@ impl TaskDefinition {
         max_depth: usize,
     ) -> Result<(), crate::GenjaError> {
         self.start_with_retry_defaults(
-            Arc::clone(&self.inner),
             hostname,
             host,
             results,
@@ -3556,7 +3555,6 @@ impl TaskDefinition {
         max_depth: usize,
     ) -> Result<(), crate::GenjaError> {
         self.start_with_retry_defaults(
-            Arc::clone(&self.inner),
             hostname,
             host,
             results,
@@ -3578,7 +3576,6 @@ impl TaskDefinition {
         max_depth: usize,
     ) -> Result<(), crate::GenjaError> {
         self.start_with_retry_defaults(
-            Arc::clone(&self.inner),
             hostname,
             host,
             results,
@@ -3591,7 +3588,6 @@ impl TaskDefinition {
 
     async fn start_with_retry_defaults(
         &self,
-        task: Arc<dyn Task>,
         hostname: &str,
         host: &Host,
         results: &mut TaskResults,
@@ -3600,7 +3596,7 @@ impl TaskDefinition {
         retry_defaults: TaskRetryDefaults,
     ) -> Result<(), crate::GenjaError> {
         Self::start_with_depth(
-            task,
+            Arc::clone(&self.inner),
             hostname,
             host,
             results,
@@ -3699,7 +3695,7 @@ impl TaskDefinition {
             let started_at = SystemTime::now();
             let finished_at = started_at;
             let error =
-                crate::GenjaError::Message(format!("max task depth exceeded: {}", max_depth));
+                crate::GenjaError::Message(format!("max task depth exceeded: {max_depth}"));
             warn!(
                 "max task depth exceeded for task '{}' at depth {} with max_depth {}",
                 task.name(),

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -28,7 +28,9 @@ struct AsyncTask {
 #[genja_task(
     name = "async_task",
     connection_plugin_name = "ssh",
-    processors = ["audit", "metrics"]
+    processors = ["audit", "metrics"],
+    allow_retries = true,
+    max_task_attempts = 3
 )]
 impl AsyncTask {
     async fn start_async(
@@ -89,6 +91,8 @@ fn genja_task_generates_task_info_from_metadata() {
     assert_eq!(task.name(), "async_task");
     assert_eq!(task.connection_plugin_name(), Some("ssh"));
     assert_eq!(task.processor_names(), vec!["audit", "metrics"]);
+    assert_eq!(task.allow_retries(), Some(true));
+    assert_eq!(task.max_task_attempts(), Some(3));
     assert_eq!(task.options(), Some(&json!({"changed": false})));
     assert!(task.helper());
 }

--- a/genja-core/tests/ui_genja_task/fail/async_start.stderr
+++ b/genja-core/tests/ui_genja_task/fail/async_start.stderr
@@ -10,7 +10,7 @@ warning: unused import: `genja_core::inventory::Host`
 2 | use genja_core::inventory::Host;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default
 
 warning: unused imports: `BlockingTaskRuntimeContext`, `HostTaskResult`, and `TaskSuccess`
  --> tests/ui_genja_task/fail/async_start.rs:3:24

--- a/genja-core/tests/ui_genja_task/fail/both_start_modes.stderr
+++ b/genja-core/tests/ui_genja_task/fail/both_start_modes.stderr
@@ -10,7 +10,7 @@ warning: unused import: `genja_core::inventory::Host`
 2 | use genja_core::inventory::Host;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default
 
 warning: unused imports: `BlockingTaskRuntimeContext`, `HostTaskResult`, `TaskRuntimeContext`, and `TaskSuccess`
  --> tests/ui_genja_task/fail/both_start_modes.rs:4:5

--- a/genja-core/tests/ui_genja_task/fail/invalid_processors.stderr
+++ b/genja-core/tests/ui_genja_task/fail/invalid_processors.stderr
@@ -10,7 +10,7 @@ warning: unused import: `genja_core::inventory::Host`
 2 | use genja_core::inventory::Host;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default
 
 warning: unused imports: `HostTaskResult`, `TaskRuntimeContext`, and `TaskSuccess`
  --> tests/ui_genja_task/fail/invalid_processors.rs:3:24

--- a/genja-core/tests/ui_genja_task/fail/missing_name.stderr
+++ b/genja-core/tests/ui_genja_task/fail/missing_name.stderr
@@ -12,7 +12,7 @@ warning: unused import: `genja_core::inventory::Host`
 2 | use genja_core::inventory::Host;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default
 
 warning: unused imports: `HostTaskResult`, `TaskRuntimeContext`, and `TaskSuccess`
  --> tests/ui_genja_task/fail/missing_name.rs:3:24

--- a/genja-core/tests/ui_genja_task/fail/sync_start_async.stderr
+++ b/genja-core/tests/ui_genja_task/fail/sync_start_async.stderr
@@ -10,7 +10,7 @@ warning: unused import: `genja_core::inventory::Host`
 2 | use genja_core::inventory::Host;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default
 
 warning: unused imports: `HostTaskResult`, `TaskRuntimeContext`, and `TaskSuccess`
  --> tests/ui_genja_task/fail/sync_start_async.rs:3:24

--- a/genja-core/tests/ui_genja_task/fail/wrong_options_signature.stderr
+++ b/genja-core/tests/ui_genja_task/fail/wrong_options_signature.stderr
@@ -10,7 +10,7 @@ warning: unused import: `genja_core::inventory::Host`
 2 | use genja_core::inventory::Host;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default
 
 warning: unused imports: `HostTaskResult`, `TaskRuntimeContext`, and `TaskSuccess`
  --> tests/ui_genja_task/fail/wrong_options_signature.rs:3:24

--- a/genja-core/tests/ui_genja_task/fail/wrong_sub_tasks_signature.stderr
+++ b/genja-core/tests/ui_genja_task/fail/wrong_sub_tasks_signature.stderr
@@ -10,7 +10,7 @@ warning: unused import: `std::sync::Arc`
 1 | use std::sync::Arc;
   |     ^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+  = note: `#[warn(unused_imports)]` on by default
 
 warning: unused import: `genja_core::inventory::Host`
  --> tests/ui_genja_task/fail/wrong_sub_tasks_signature.rs:4:5

--- a/genja-plugin-manager/src/lib.rs
+++ b/genja-plugin-manager/src/lib.rs
@@ -576,7 +576,7 @@ impl PluginManager {
     /// updated `PluginManager` on success.
     pub fn activate_plugins(mut self) -> Result<PluginManager, Box<dyn std::error::Error>> {
         let meta_data = self.get_plugin_metadata();
-        log::debug!("Plugin metadata: {:?}", meta_data);
+        log::debug!("Plugin metadata: {meta_data:?}");
         let mut registrations = Vec::new();
         if let Some(plugin_config) = meta_data.plugins {
             for (group_or_name, plugin_entry) in plugin_config {
@@ -617,7 +617,7 @@ impl PluginManager {
         let manifest = match file_string {
             Ok(manifest) => manifest,
             Err(msg) => {
-                eprintln!("Error reading manifest file {}", msg);
+                eprintln!("Error reading manifest file {msg}");
                 return Metadata { plugins: None };
             }
         };
@@ -683,11 +683,11 @@ impl PluginManager {
         let path = Path::new(filename);
 
         if !path.exists() {
-            let msg = format!("Plugin file does not exist: {}", filename);
+            let msg = format!("Plugin file does not exist: {filename}");
             log::error!("{msg}");
             return Err(msg.into());
         } else {
-            log::debug!("Attempting to load plugin: {}", filename);
+            log::debug!("Attempting to load plugin: {filename}");
         }
 
         let library = unsafe { Library::new(path)? };
@@ -753,7 +753,7 @@ impl PluginManager {
     /// Panics if a plugin with the same name is already registered.
     pub fn register_plugin(&mut self, plugin: Plugins) {
         let name = plugin.name();
-        log::info!("Registering plugin: {:?}", name);
+        log::info!("Registering plugin: {name:?}");
 
         if let hash_map::Entry::Vacant(entry) = self.plugins.entry(name.clone()) {
             entry.insert(plugin);
@@ -886,7 +886,7 @@ impl PluginManager {
     /// Deregisters the plugin with the given name.
     pub fn deregister_plugin(&mut self, name: &str) -> Option<String> {
         if let Some(plugin) = self.plugins.remove(name) {
-            log::info!("De-registering plugin: {}", name);
+            log::info!("De-registering plugin: {name}");
             Some(plugin.name())
         } else {
             None
@@ -897,7 +897,7 @@ impl PluginManager {
     pub fn deregister_all_plugins(&mut self) -> Vec<String> {
         let mut deregistered_plugins = Vec::new();
         for (name, plugin) in self.plugins.drain() {
-            log::info!("De-registering plugin: {}", name);
+            log::info!("De-registering plugin: {name}");
             deregistered_plugins.push(plugin.name());
         }
         deregistered_plugins
@@ -914,9 +914,9 @@ impl PluginManager {
 
         for (name, plugin) in other.plugins {
             if self.plugins.insert(name.clone(), plugin).is_some() {
-                log::info!("Overriding plugin: {}", name);
+                log::info!("Overriding plugin: {name}");
             } else {
-                log::info!("Registering merged plugin: {}", name);
+                log::info!("Registering merged plugin: {name}");
             }
         }
     }
@@ -1042,7 +1042,7 @@ mod tests {
             "macos" => "Cargo-macos.toml",
             _ => "Cargo.toml",
         };
-        let file = format!("../genja-plugin-manager/tests/plugin_mods/{}", file_name);
+        let file = format!("../genja-plugin-manager/tests/plugin_mods/{file_name}");
         unsafe {
             std::env::set_var("CARGO_MANIFEST_PATH", file);
         }
@@ -1383,7 +1383,7 @@ inventory_a = "../this/path/does/not/exist.so"
 
         // Verify the debug output format for base plugins
         for (name, plugin) in connection_plugins {
-            let debug_output = format!("{:?}", plugin);
+            let debug_output = format!("{plugin:?}");
             assert!(debug_output.contains("ConnectionPlugin"));
             assert!(debug_output.contains(name));
         }

--- a/genja/README.md
+++ b/genja/README.md
@@ -15,7 +15,8 @@ automation workflows.
 - Run single tasks or ordered task lists across selected hosts
 - Execute hierarchical task trees with bounded recursion depth
 - Load Genja-compatible inventory, runner, connection, and processor plugins
-- Track per-host task results, sub-task results, summaries, timing, and status
+- Track per-host task outcomes plus execution metadata, nested sub-task results,
+  summaries, timing, and status
 
 ## Installation
 
@@ -165,7 +166,10 @@ let genja = Genja::builder(inventory).build()?;
 
 let results = genja.run_task(CheckConfig, 1)?;
 
-assert!(results.host_result("router1").unwrap().is_passed());
+let host_result = results.host_result("router1").unwrap();
+assert!(host_result.is_passed());
+assert_eq!(host_result.status(), "passed");
+assert_eq!(host_result.execution_metadata().attempts(), 1);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 

--- a/genja/src/lib.rs
+++ b/genja/src/lib.rs
@@ -2296,7 +2296,12 @@ mod tests {
             .expect("router1 should have a failed result");
         assert!(host_result.is_failed());
         assert!(host_result.execution_metadata().duration_ns().is_some());
-        assert!(host_result.execution_metadata().duration_display().is_some());
+        assert!(
+            host_result
+                .execution_metadata()
+                .duration_display()
+                .is_some()
+        );
         assert!(results.duration_ns().is_some());
     }
 

--- a/genja/src/lib.rs
+++ b/genja/src/lib.rs
@@ -1119,7 +1119,7 @@ impl Genja {
             let host = inventory
                 .hosts()
                 .get(host_id)
-                .ok_or_else(|| GenjaError::Message(format!("host '{}' not found", host_id)))?;
+                .ok_or_else(|| GenjaError::Message(format!("host '{host_id}' not found")))?;
             hosts.add_host(host_id.as_str(), host.clone());
         }
 

--- a/genja/src/lib.rs
+++ b/genja/src/lib.rs
@@ -2202,12 +2202,12 @@ mod tests {
         let results = genja.run_task(FailedTask, 0).expect("run should succeed");
 
         assert_eq!(results.failed_hosts().len(), 2);
-        let failure = results
+        let host_result = results
             .host_result("router1")
-            .and_then(genja_core::task::HostTaskResult::failure)
             .expect("router1 should have a failed result");
-        assert!(failure.duration_ns().is_some());
-        assert!(failure.duration_display().is_some());
+        assert!(host_result.is_failed());
+        assert!(host_result.execution_metadata().duration_ns().is_some());
+        assert!(host_result.execution_metadata().duration_display().is_some());
         assert!(results.duration_ns().is_some());
     }
 

--- a/genja/src/lib.rs
+++ b/genja/src/lib.rs
@@ -1145,14 +1145,14 @@ mod tests {
     use genja_core::settings::{InventoryConfig, RunnerConfig};
     use genja_core::task::{
         BlockingTaskRuntimeContext, HostTaskResult, Task, TaskDefinition, TaskError,
-        TaskExecutionMode, TaskInfo, TaskRuntimeContext, TaskSuccess, Tasks,
+        TaskExecutionMode, TaskFailure, TaskInfo, TaskRuntimeContext, TaskSuccess, Tasks,
     };
     use genja_plugin_manager::PluginManager;
     use genja_plugin_manager::plugin_types::{
         AsyncPluginInventory, Plugin, PluginConnection, Plugins,
     };
     use serde_json::{Value, json};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -1249,6 +1249,11 @@ mod tests {
 
     struct SkippedTask;
 
+    struct FlakyRetryTask {
+        attempts: Arc<AtomicUsize>,
+        succeed_on_attempt: usize,
+    }
+
     impl TaskInfo for SkippedTask {
         fn name(&self) -> &str {
             "skipped-task"
@@ -1271,6 +1276,45 @@ mod tests {
             _context: &TaskRuntimeContext,
         ) -> Result<HostTaskResult, TaskError> {
             Ok(HostTaskResult::skipped_with_reason("filtered"))
+        }
+
+        fn execution_mode(&self) -> TaskExecutionMode {
+            TaskExecutionMode::Async
+        }
+    }
+
+    impl TaskInfo for FlakyRetryTask {
+        fn name(&self) -> &str {
+            "flaky-retry-task"
+        }
+
+        fn connection_plugin_name(&self) -> Option<&str> {
+            None
+        }
+
+        fn options(&self) -> Option<&Value> {
+            None
+        }
+    }
+
+    #[async_trait]
+    impl Task for FlakyRetryTask {
+        async fn start_async(
+            &self,
+            _host: &Host,
+            _context: &TaskRuntimeContext,
+        ) -> Result<HostTaskResult, TaskError> {
+            let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            if attempt < self.succeed_on_attempt {
+                return Ok(HostTaskResult::failed(
+                    TaskFailure::new(std::io::Error::other("temporary failure"))
+                        .with_retryable(true),
+                ));
+            }
+
+            Ok(HostTaskResult::passed(
+                TaskSuccess::new().with_summary("recovered after retry"),
+            ))
         }
 
         fn execution_mode(&self) -> TaskExecutionMode {
@@ -1988,6 +2032,51 @@ mod tests {
         assert!(results.started_at().is_some());
         assert!(results.finished_at().is_some());
         assert!(results.duration_ns().is_some());
+    }
+
+    #[test]
+    fn run_preserves_retry_behavior_across_serial_and_threaded_runners() {
+        for runner_plugin in ["serial", "threaded"] {
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let settings = Settings::builder()
+                .runner(
+                    RunnerConfig::builder()
+                        .plugin(runner_plugin)
+                        .worker_count(2)
+                        .allow_retries(true)
+                        .max_task_attempts(3)
+                        .build(),
+                )
+                .build();
+
+            let genja = Genja::builder(single_host_inventory())
+                .with_settings(settings)
+                .build()
+                .expect("genja should build with retry settings");
+
+            let results = genja
+                .run_task(
+                    FlakyRetryTask {
+                        attempts: Arc::clone(&attempts),
+                        succeed_on_attempt: 2,
+                    },
+                    0,
+                )
+                .expect("runner should retry and succeed");
+
+            assert_eq!(
+                attempts.load(Ordering::SeqCst),
+                2,
+                "{runner_plugin} runner should execute exactly two attempts"
+            );
+            let host_result = results
+                .host_result("router1")
+                .expect("router1 should have a host result");
+            assert!(host_result.is_passed());
+            assert_eq!(host_result.execution_metadata().attempts(), 2);
+            assert!(host_result.execution_metadata().retried());
+            assert!(!host_result.execution_metadata().retry_exhausted());
+        }
     }
 
     #[tokio::test]

--- a/genja/src/plugins/runners/executor.rs
+++ b/genja/src/plugins/runners/executor.rs
@@ -20,6 +20,7 @@ use std::time::SystemTime;
 pub(crate) struct TaskExecutor<'a> {
     hosts: &'a Hosts,
     connection_resolver: Option<Arc<dyn TaskConnectionResolver>>,
+    runner_config: &'a genja_core::settings::RunnerConfig,
     max_depth: usize,
 }
 
@@ -43,11 +44,13 @@ impl<'a> TaskExecutor<'a> {
     pub(crate) fn new(
         hosts: &'a Hosts,
         connection_resolver: Option<Arc<dyn TaskConnectionResolver>>,
+        runner_config: &'a genja_core::settings::RunnerConfig,
         max_depth: usize,
     ) -> Self {
         Self {
             hosts,
             connection_resolver,
+            runner_config,
             max_depth,
         }
     }
@@ -93,6 +96,7 @@ impl<'a> TaskExecutor<'a> {
                     host_id,
                     host,
                     self.connection_resolver.clone(),
+                    self.runner_config,
                     self.max_depth,
                 )
                 .await?,
@@ -146,15 +150,17 @@ impl<'a> TaskExecutor<'a> {
         host_id: &NatString,
         host: &Host,
         connection_resolver: Option<Arc<dyn TaskConnectionResolver>>,
+        runner_config: &genja_core::settings::RunnerConfig,
         max_depth: usize,
     ) -> Result<TaskResults, GenjaError> {
         let mut results = TaskResults::new(task_definition.name());
         task_definition
-            .start_with_connection_resolver(
+            .start_with_connection_resolver_and_runner_config(
                 host_id.as_str(),
                 host,
                 &mut results,
                 connection_resolver.as_deref(),
+                runner_config,
                 max_depth,
             )
             .await?;

--- a/genja/src/plugins/runners/serial.rs
+++ b/genja/src/plugins/runners/serial.rs
@@ -116,10 +116,10 @@ impl PluginRunner for SerialRunnerPlugin {
         task: &TaskDefinition,
         hosts: &Hosts,
         connection_resolver: Option<std::sync::Arc<dyn genja_core::task::TaskConnectionResolver>>,
-        _runner_config: &RunnerConfig,
+        runner_config: &RunnerConfig,
         max_depth: usize,
     ) -> Result<TaskResults, GenjaError> {
-        TaskExecutor::new(hosts, connection_resolver, max_depth)
+        TaskExecutor::new(hosts, connection_resolver, runner_config, max_depth)
             .run_definition(task)
             .await
     }

--- a/genja/src/plugins/runners/threaded.rs
+++ b/genja/src/plugins/runners/threaded.rs
@@ -344,8 +344,7 @@ impl PluginRunner for ThreadedRunnerPlugin {
                         err
                     );
                     return Err(GenjaError::Message(format!(
-                        "threaded runner worker task failed: {}",
-                        err
+                        "threaded runner worker task failed: {err}"
                     )));
                 }
             }

--- a/genja/src/plugins/runners/threaded.rs
+++ b/genja/src/plugins/runners/threaded.rs
@@ -312,8 +312,17 @@ impl PluginRunner for ThreadedRunnerPlugin {
             };
             let task = task.clone();
             let connection_resolver = connection_resolver.clone();
+            let runner_config = runner_config.clone();
             join_set.spawn(async move {
-                TaskExecutor::run_host(&task, &host_id, &host, connection_resolver, max_depth).await
+                TaskExecutor::run_host(
+                    &task,
+                    &host_id,
+                    &host,
+                    connection_resolver,
+                    &runner_config,
+                    max_depth,
+                )
+                .await
             });
         }
 
@@ -344,9 +353,17 @@ impl PluginRunner for ThreadedRunnerPlugin {
             if let Some((host_id, host)) = jobs_iter.next() {
                 let task = task.clone();
                 let connection_resolver = connection_resolver.clone();
+                let runner_config = runner_config.clone();
                 join_set.spawn(async move {
-                    TaskExecutor::run_host(&task, &host_id, &host, connection_resolver, max_depth)
-                        .await
+                    TaskExecutor::run_host(
+                        &task,
+                        &host_id,
+                        &host,
+                        connection_resolver,
+                        &runner_config,
+                        max_depth,
+                    )
+                    .await
                 });
             }
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.0"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"
 components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.88.0"
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- add per-host task retry support in the open-core runtime
- add runner-level retry defaults with task-level overrides
- redesign `HostTaskResult` to separate semantic `outcome` from `execution_metadata`
- remove duplicated timing data from `TaskSuccess` and `TaskFailure`
- update Rust, Python, serialization, tests, and docs to match

## What Changed

- added `allow_retries` and `max_task_attempts` to runner config
- added task-level retry overrides in Rust and Python task metadata
- retries now occur only when:
  - retry policy allows them
  - the task returns a failed host result marked `retryable`
- `HostTaskResult` now stores:
  - `outcome`
  - `execution_metadata`
- host execution metadata now includes:
  - timing
  - attempts
  - `retried`
  - `retry_exhausted`

## Breaking Changes

- `HostTaskResult` changed from enum-style consumption to a structured object
- host timing is no longer duplicated inside success/failure payloads
- `TaskSuccess` and `TaskFailure` no longer expose execution timing fields/accessors

## Migration

- replace direct enum variant matching with `outcome()` or compatibility helpers such as `is_passed()`, `success()`, `failure()`, and `skipped_detail()`
- read per-host timing and retry data from `HostTaskResult.execution_metadata()`
- read aggregate task timing from `TaskResults`

## Testing

- added coverage for:
  - retryable vs non-retryable failures
  - success after retry
  - retry exhaustion
  - skipped results not retried
  - `max_task_attempts = 1`
  - serial/threaded parity

## Docs

- updated task, runner, settings, README, and Rustdoc documentation
- documented that Genja does not infer mutability or idempotency; retries are explicit policy decisions

Refs: #63