### PR TITLE
Feature - 110 execution overrides to declarative task specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changed packages:
 - Added Rust task registration identity helper APIs for looking up and constructing compiled tasks from `<task-id>@<task-version>` strings. Refs: #91
 - Added runnable Rust examples for task registration schema output and custom factory construction. Refs: #91
 - Added core Rust `TaskSpec` APIs for single-task declarative construction specs with explicit and auto-detected JSON/YAML parsing and compiled task construction helpers. Refs: #109
+- Added Rust task spec runtime policy overrides for retry and session verification during compiled task construction. Refs: #110
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -48,7 +48,7 @@ cargo run -p genja --example task_registration_spec
 | `async_inventory_plugin.rs` | Implementing an async Rust inventory plugin and building a runtime from generated inventory. |
 | `task_registration.rs` | Registering a Rust task, listing compiled descriptors, printing schema JSON, and constructing by `<id>@<version>`. |
 | `task_registration_custom_factory.rs` | Registering a Rust task with a custom factory for prepared JSON input and sanitized validation errors. |
-| `task_registration_spec.rs` | Constructing a registered Rust task from YAML and JSON task spec strings. |
+| `task_registration_spec.rs` | Constructing a registered Rust task from YAML and JSON task spec strings, including retry and session verification overrides. |
 
 Use the Rust examples when you want to see the public `genja` crate, the
 `#[genja_task]` macro, and Rust plugin traits in context.

--- a/docs/task-registration.md
+++ b/docs/task-registration.md
@@ -299,8 +299,8 @@ APIs can store and execute different task types through one interface.
 
 Use `TaskSpec` when the caller supplies a single task invocation as text, such
 as a CLI file, API request, or MCP tool payload. A task spec contains the
-registered task identity and the JSON-compatible input passed to that task's
-factory.
+registered task identity, the JSON-compatible input passed to that task's
+factory, and optional runtime policy overrides.
 
 YAML:
 
@@ -312,6 +312,14 @@ input:
   rules:
     - path: /etc/network
       recursive: true
+overrides:
+  retry:
+    allow: true
+    max_attempts: 3
+    delay_ms: 500
+  session_verification:
+    max_attempts: 2
+    delay_ms: 1000
 ```
 
 JSON:
@@ -328,6 +336,17 @@ JSON:
         "recursive": true
       }
     ]
+  },
+  "overrides": {
+    "retry": {
+      "allow": true,
+      "max_attempts": 3,
+      "delay_ms": 500
+    },
+    "session_verification": {
+      "max_attempts": 2,
+      "delay_ms": 1000
+    }
   }
 }
 ```
@@ -353,12 +372,27 @@ println!("created task {}", task.name());
 
 `parse_auto(...)` tries JSON first, then YAML. If neither parser accepts the
 input, Genja returns an auto-parse error that includes both parser messages. If
-the text parses but is not an object with `task` and optional `input`, Genja
-returns a task-spec shape error instead of treating it as a registry failure.
+the text parses but is not an object with `task`, optional `input`, and optional
+`overrides`, Genja returns a task-spec shape error instead of treating it as a
+registry failure.
 
-This is a single-task construction spec. It is not a workflow DSL, task list,
-or execution override model. Future work can build those features on top of the
-same registered task identity and JSON-compatible input contract.
+Overrides are narrow per-run runtime policy controls. The first supported
+fields are:
+
+| Override | Effect |
+| --- | --- |
+| `retry` | Overrides the constructed task's retry policy for this run. |
+| `session_verification` | Overrides post-change session verification policy for this run. |
+
+Overrides do not rewrite authored task behavior. The spec intentionally does
+not support overriding processors, connection plugin names, execution mode,
+task identity, factory strategy, schema, or registration metadata. In
+particular, processor overrides are rejected because processors can affect
+startup hooks, result handling, and side effects selected by the task author.
+
+This is a single-task construction spec. It is not a workflow DSL or task list.
+Future work can build those features on top of the same registered task
+identity and JSON-compatible input contract.
 
 Run the complete task spec example from the repository root:
 

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -656,7 +656,7 @@ pub use registration::{
     validate_task_version,
 };
 pub use spec::{
-    TaskSpec, TaskSpecConstructionError, TaskSpecError, TaskSpecFormat,
+    TaskSpec, TaskSpecConstructionError, TaskSpecError, TaskSpecFormat, TaskSpecOverrides,
     create_compiled_task_from_spec, create_compiled_task_from_spec_str,
     create_compiled_task_from_spec_str_with_format,
 };
@@ -4270,6 +4270,8 @@ pub struct TaskDefinition {
     inner: Arc<dyn Task>,
     processor_resolver: Option<Arc<dyn TaskProcessorResolver>>,
     processor_names: Arc<Vec<String>>,
+    retry_config_override: Option<RetryConfig>,
+    session_verification_config_override: Option<SessionVerificationConfig>,
 }
 
 impl fmt::Debug for TaskDefinition {
@@ -4280,6 +4282,11 @@ impl fmt::Debug for TaskDefinition {
             .field("connection_plugin_name", &self.connection_plugin_name())
             .field("processor_names", &self.processor_names())
             .field("has_processor_resolver", &self.processor_resolver.is_some())
+            .field("retry_config_override", &self.retry_config_override)
+            .field(
+                "session_verification_config_override",
+                &self.session_verification_config_override,
+            )
             .finish()
     }
 }
@@ -4291,6 +4298,8 @@ impl TaskDefinition {
             inner: Arc::new(task),
             processor_resolver: None,
             processor_names: Arc::new(Vec::new()),
+            retry_config_override: None,
+            session_verification_config_override: None,
         }
     }
 
@@ -4325,6 +4334,27 @@ impl TaskDefinition {
         processor_resolver: Arc<dyn TaskProcessorResolver>,
     ) -> Self {
         self.processor_resolver = Some(processor_resolver);
+        self
+    }
+
+    /// Override the root task's retry policy for this task definition.
+    ///
+    /// This is a per-definition runtime policy override. It does not mutate the
+    /// authored task metadata and does not apply to sub-tasks.
+    pub fn with_retry_config_override(mut self, retry_config: RetryConfig) -> Self {
+        self.retry_config_override = Some(retry_config);
+        self
+    }
+
+    /// Override the root task's post-change session verification policy.
+    ///
+    /// This is a per-definition runtime policy override. It does not mutate the
+    /// authored task metadata and does not apply to sub-tasks.
+    pub fn with_session_verification_config_override(
+        mut self,
+        session_verification_config: SessionVerificationConfig,
+    ) -> Self {
+        self.session_verification_config_override = Some(session_verification_config);
         self
     }
 
@@ -5136,11 +5166,15 @@ impl TaskInfo for TaskDefinition {
     }
 
     fn retry_config(&self) -> Option<&RetryConfig> {
-        self.inner.retry_config()
+        self.retry_config_override
+            .as_ref()
+            .or_else(|| self.inner.retry_config())
     }
 
     fn session_verification_config(&self) -> Option<&SessionVerificationConfig> {
-        self.inner.session_verification_config()
+        self.session_verification_config_override
+            .as_ref()
+            .or_else(|| self.inner.session_verification_config())
     }
 
     fn supports_dry_run(&self) -> bool {
@@ -8123,6 +8157,50 @@ mod tests {
         let task = TaskDefinition::new(DryRunInfoTask);
 
         assert!(task.supports_dry_run());
+    }
+
+    #[test]
+    fn task_definition_retry_override_wins_over_authored_metadata() {
+        let task = TaskDefinition::new(RetryConfiguredFlakyTask {
+            inner: FlakyTask {
+                name: "retry-override",
+                attempts: Arc::new(AtomicUsize::new(0)),
+                succeed_on_attempt: 1,
+            },
+            retry_config: RetryConfig::builder()
+                .allow(true)
+                .max_attempts(3)
+                .delay_ms(100)
+                .build(),
+        })
+        .with_retry_config_override(
+            RetryConfig::builder()
+                .allow(false)
+                .max_attempts(2)
+                .delay_ms(250)
+                .build(),
+        );
+
+        let retry_config = task
+            .retry_config()
+            .expect("retry override should be present");
+        assert_eq!(retry_config.allow(), Some(false));
+        assert_eq!(retry_config.max_attempts(), Some(2));
+        assert_eq!(retry_config.delay_ms(), Some(250));
+    }
+
+    #[test]
+    fn task_definition_session_verification_override_wins_over_authored_metadata() {
+        let task = TaskDefinition::new(SessionVerificationInfoTask {
+            config: SessionVerificationConfig::new(3, 5_000),
+        })
+        .with_session_verification_config_override(SessionVerificationConfig::new(2, 1_000));
+
+        let config = task
+            .session_verification_config()
+            .expect("session verification override should be present");
+        assert_eq!(config.max_attempts(), 2);
+        assert_eq!(config.delay_ms(), 1_000);
     }
 
     #[test]

--- a/genja-core/src/task/spec.rs
+++ b/genja-core/src/task/spec.rs
@@ -2,8 +2,9 @@
 //!
 //! `TaskSpec` is the minimal data model for constructing one registered task
 //! from a stable task identity and JSON-compatible input. It can also carry
-//! narrow per-run runtime policy overrides. It intentionally does not run tasks,
-//! define task lists, or provide a workflow language.
+//! narrow per-run runtime policy overrides for retry and session verification.
+//! It intentionally does not run tasks, define task lists, change processors,
+//! or provide a workflow language.
 
 use super::{
     RetryConfig, SessionVerificationConfig, TaskDefinition, TaskRegistrationError,
@@ -52,6 +53,9 @@ pub enum TaskSpecError {
         message: String,
     },
     /// A task spec override is unsupported or invalid.
+    ///
+    /// Only `retry` and `session_verification` are currently supported under
+    /// `overrides`.
     InvalidOverride {
         /// Override field path.
         field: String,
@@ -144,7 +148,7 @@ impl From<TaskRegistrationError> for TaskSpecConstructionError {
 /// Overrides are intentionally narrow. They can tune runtime policy for a
 /// single constructed task, but they do not rewrite authored task behavior,
 /// change processors, change connection plugins, or alter registration
-/// metadata.
+/// metadata. The supported fields are `retry` and `session_verification`.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaskSpecOverrides {

--- a/genja-core/src/task/spec.rs
+++ b/genja-core/src/task/spec.rs
@@ -1,12 +1,13 @@
 //! Declarative task invocation specs.
 //!
 //! `TaskSpec` is the minimal data model for constructing one registered task
-//! from a stable task identity and JSON-compatible input. It intentionally does
-//! not run tasks, define task lists, apply execution overrides, or provide a
-//! workflow language.
+//! from a stable task identity and JSON-compatible input. It can also carry
+//! narrow per-run runtime policy overrides. It intentionally does not run tasks,
+//! define task lists, or provide a workflow language.
 
 use super::{
-    TaskDefinition, TaskRegistrationError, TaskRegistrationKey, create_compiled_task_by_identity,
+    RetryConfig, SessionVerificationConfig, TaskDefinition, TaskRegistrationError,
+    TaskRegistrationKey, create_compiled_task_by_identity,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -50,6 +51,13 @@ pub enum TaskSpecError {
         /// Human-readable shape failure.
         message: String,
     },
+    /// A task spec override is unsupported or invalid.
+    InvalidOverride {
+        /// Override field path.
+        field: String,
+        /// Human-readable validation failure.
+        message: String,
+    },
     /// The `task` identity failed `<task-id>@<task-version>` validation.
     InvalidTaskIdentity {
         /// Invalid identity value.
@@ -79,6 +87,9 @@ impl fmt::Display for TaskSpecError {
             }
             Self::InvalidShape { message } => {
                 write!(f, "invalid task spec: {message}")
+            }
+            Self::InvalidOverride { field, message } => {
+                write!(f, "invalid task spec override `{field}`: {message}")
             }
             Self::InvalidTaskIdentity { identity, reason } => {
                 write!(f, "invalid task spec identity `{identity}`: {reason}")
@@ -128,12 +139,46 @@ impl From<TaskRegistrationError> for TaskSpecConstructionError {
     }
 }
 
+/// Per-run runtime policy overrides for a declarative task spec.
+///
+/// Overrides are intentionally narrow. They can tune runtime policy for a
+/// single constructed task, but they do not rewrite authored task behavior,
+/// change processors, change connection plugins, or alter registration
+/// metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskSpecOverrides {
+    /// Optional retry policy override for this task construction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry: Option<RetryConfig>,
+    /// Optional post-change session verification override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_verification: Option<SessionVerificationConfig>,
+}
+
+impl TaskSpecOverrides {
+    /// Validate override values.
+    pub fn validate(&self) -> Result<(), TaskSpecError> {
+        if let Some(config) = self.session_verification
+            && config.max_attempts() == 0
+        {
+            return Err(TaskSpecError::InvalidOverride {
+                field: "overrides.session_verification.max_attempts".to_string(),
+                message: "must be greater than 0".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
 /// Declarative spec for constructing one registered task.
 ///
 /// `task` must be a rendered registration identity in
 /// `<task-id>@<task-version>` form. `input` is passed to the registered task
 /// factory as JSON-compatible construction input. When `input` is omitted, it
-/// defaults to an empty object.
+/// defaults to an empty object. `overrides` can tune narrow runtime policy for
+/// the constructed task without changing the authored task behavior.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaskSpec {
@@ -142,6 +187,9 @@ pub struct TaskSpec {
     /// JSON-compatible task construction input.
     #[serde(default = "empty_input")]
     pub input: Value,
+    /// Optional per-run runtime policy overrides.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overrides: Option<TaskSpecOverrides>,
 }
 
 impl TaskSpec {
@@ -150,6 +198,7 @@ impl TaskSpec {
         let spec = Self {
             task: task.into(),
             input,
+            overrides: None,
         };
         spec.validate()?;
         Ok(spec)
@@ -207,9 +256,12 @@ impl TaskSpec {
         let object = value.as_object().ok_or_else(expected_shape_error)?;
         if !object.contains_key("task") {
             return Err(TaskSpecError::InvalidShape {
-                message: "missing required field `task`; expected an object with `task` and optional `input`".to_string(),
+                message:
+                    "missing required field `task`; expected an object with `task`, optional `input`, and optional `overrides`"
+                        .to_string(),
             });
         }
+        validate_overrides_shape(object)?;
 
         let spec: Self =
             serde_json::from_value(value).map_err(|error| TaskSpecError::InvalidShape {
@@ -227,6 +279,9 @@ impl TaskSpec {
                 reason: error.to_string(),
             }
         })?;
+        if let Some(overrides) = &self.overrides {
+            overrides.validate()?;
+        }
         Ok(())
     }
 }
@@ -241,8 +296,32 @@ fn parse_yaml_value(source: &str) -> Result<Value, String> {
 
 fn expected_shape_error() -> TaskSpecError {
     TaskSpecError::InvalidShape {
-        message: "expected an object with `task` and optional `input`".to_string(),
+        message: "expected an object with `task`, optional `input`, and optional `overrides`"
+            .to_string(),
     }
+}
+
+fn validate_overrides_shape(object: &Map<String, Value>) -> Result<(), TaskSpecError> {
+    let Some(overrides) = object.get("overrides") else {
+        return Ok(());
+    };
+    let overrides = overrides
+        .as_object()
+        .ok_or_else(|| TaskSpecError::InvalidOverride {
+            field: "overrides".to_string(),
+            message: "expected an object".to_string(),
+        })?;
+
+    for key in overrides.keys() {
+        if key != "retry" && key != "session_verification" {
+            return Err(TaskSpecError::InvalidOverride {
+                field: format!("overrides.{key}"),
+                message: "unsupported override field".to_string(),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 impl FromStr for TaskSpec {
@@ -263,7 +342,8 @@ impl FromStr for TaskSpec {
 pub fn create_compiled_task_from_spec(
     spec: TaskSpec,
 ) -> Result<TaskDefinition, TaskSpecConstructionError> {
-    create_compiled_task_by_identity(&spec.task, spec.input).map_err(Into::into)
+    let task = create_compiled_task_by_identity(&spec.task, spec.input)?;
+    Ok(apply_overrides(task, spec.overrides))
 }
 
 /// Parse a task spec string with auto JSON/YAML parsing and construct its task.
@@ -283,6 +363,22 @@ pub fn create_compiled_task_from_spec_str_with_format(
 
 fn empty_input() -> Value {
     Value::Object(Map::new())
+}
+
+fn apply_overrides(task: TaskDefinition, overrides: Option<TaskSpecOverrides>) -> TaskDefinition {
+    let Some(overrides) = overrides else {
+        return task;
+    };
+    let task = if let Some(retry) = overrides.retry {
+        task.with_retry_config_override(retry)
+    } else {
+        task
+    };
+    if let Some(session_verification) = overrides.session_verification {
+        task.with_session_verification_config_override(session_verification)
+    } else {
+        task
+    }
 }
 
 #[cfg(test)]
@@ -489,7 +585,9 @@ input:
         assert_eq!(
             error,
             TaskSpecError::InvalidShape {
-                message: "expected an object with `task` and optional `input`".to_string(),
+                message:
+                    "expected an object with `task`, optional `input`, and optional `overrides`"
+                        .to_string(),
             }
         );
     }
@@ -502,7 +600,82 @@ input:
         assert_eq!(
             error,
             TaskSpecError::InvalidShape {
-                message: "missing required field `task`; expected an object with `task` and optional `input`".to_string(),
+                message:
+                    "missing required field `task`; expected an object with `task`, optional `input`, and optional `overrides`"
+                        .to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn task_spec_parses_retry_and_session_verification_overrides() {
+        let spec = TaskSpec::from_yaml_str(
+            r#"
+task: acme.examples.backup_config@1.0.0
+input:
+  backup_path: /tmp/configs
+overrides:
+  retry:
+    allow: true
+    max_attempts: 4
+    delay_ms: 250
+  session_verification:
+    max_attempts: 2
+    delay_ms: 1000
+"#,
+        )
+        .expect("task spec overrides should parse");
+
+        let overrides = spec.overrides.expect("overrides should be present");
+        let retry = overrides.retry.expect("retry override should be present");
+        assert_eq!(retry.allow(), Some(true));
+        assert_eq!(retry.max_attempts(), Some(4));
+        assert_eq!(retry.delay_ms(), Some(250));
+        let session_verification = overrides
+            .session_verification
+            .expect("session verification override should be present");
+        assert_eq!(session_verification.max_attempts(), 2);
+        assert_eq!(session_verification.delay_ms(), 1000);
+    }
+
+    #[test]
+    fn task_spec_rejects_unsupported_processor_override() {
+        let error = TaskSpec::from_yaml_str(
+            r#"
+task: acme.examples.backup_config@1.0.0
+overrides:
+  processors: ["audit"]
+"#,
+        )
+        .expect_err("processor override should be unsupported");
+
+        assert_eq!(
+            error,
+            TaskSpecError::InvalidOverride {
+                field: "overrides.processors".to_string(),
+                message: "unsupported override field".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn task_spec_rejects_invalid_session_verification_override() {
+        let error = TaskSpec::from_yaml_str(
+            r#"
+task: acme.examples.backup_config@1.0.0
+overrides:
+  session_verification:
+    max_attempts: 0
+    delay_ms: 1000
+"#,
+        )
+        .expect_err("invalid session verification override should be rejected");
+
+        assert_eq!(
+            error,
+            TaskSpecError::InvalidOverride {
+                field: "overrides.session_verification.max_attempts".to_string(),
+                message: "must be greater than 0".to_string(),
             }
         );
     }
@@ -531,6 +704,8 @@ input:
 
         assert_eq!(yaml.input, json!({}));
         assert_eq!(json.input, json!({}));
+        assert_eq!(yaml.overrides, None);
+        assert_eq!(json.overrides, None);
     }
 
     #[test]
@@ -582,10 +757,10 @@ input:
         let error = serde_json::from_value::<TaskSpec>(json!({
             "task": "acme.examples.backup_config@1.0.0",
             "input": {},
-            "overrides": {},
+            "metadata": {},
         }))
         .expect_err("unknown fields should be rejected");
 
-        assert!(error.to_string().contains("unknown field `overrides`"));
+        assert!(error.to_string().contains("unknown field `metadata`"));
     }
 }

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -321,6 +321,36 @@ impl RegisteredSchemaTask {
     }
 }
 
+#[derive(serde::Deserialize)]
+struct RegisteredOverrideMetadataTask {
+    options: Value,
+}
+
+#[genja_task(
+    name = "registered_override_metadata_task",
+    connection_plugin_name = "ssh",
+    retry(allow = true, max_attempts = 3, delay_ms = 500),
+    session_verification(max_attempts = 3, delay_ms = 2000),
+    registration(
+        id = "acme.tests.derive_runtime.registered_override_metadata_task",
+        version = "1.0.0",
+        description = "Provides authored runtime metadata for override tests"
+    )
+)]
+impl RegisteredOverrideMetadataTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+
+    fn options(&self) -> Option<&Value> {
+        Some(&self.options)
+    }
+}
+
 #[test]
 fn genja_task_generates_task_info_from_metadata() {
     let task = AsyncTask {
@@ -462,6 +492,87 @@ fn genja_task_compiled_registry_creates_task_from_json_spec() {
 
     assert_eq!(task.name(), "registered_serde_task");
     assert_eq!(task.options(), Some(&json!({ "source": "json-spec" })));
+}
+
+#[test]
+fn genja_task_compiled_registry_applies_task_spec_runtime_overrides() {
+    let task = create_compiled_task_from_spec_str(
+        r#"
+task: acme.tests.derive_runtime.registered_override_metadata_task@1.0.0
+input:
+  options:
+    source: overrides
+overrides:
+  retry:
+    allow: false
+    max_attempts: 2
+    delay_ms: 250
+  session_verification:
+    max_attempts: 2
+    delay_ms: 1000
+"#,
+    )
+    .expect("task spec with runtime overrides should construct task");
+
+    assert_eq!(task.name(), "registered_override_metadata_task");
+    assert_eq!(task.options(), Some(&json!({ "source": "overrides" })));
+    let retry = task
+        .retry_config()
+        .expect("retry override should be present");
+    assert_eq!(retry.allow(), Some(false));
+    assert_eq!(retry.max_attempts(), Some(2));
+    assert_eq!(retry.delay_ms(), Some(250));
+    let session_verification = task
+        .session_verification_config()
+        .expect("session verification override should be present");
+    assert_eq!(session_verification.max_attempts(), 2);
+    assert_eq!(session_verification.delay_ms(), 1000);
+}
+
+#[test]
+fn genja_task_compiled_registry_preserves_authored_metadata_without_spec_overrides() {
+    let task = create_compiled_task_from_spec_str(
+        r#"
+task: acme.tests.derive_runtime.registered_override_metadata_task@1.0.0
+input:
+  options:
+    source: authored
+"#,
+    )
+    .expect("task spec without runtime overrides should construct task");
+
+    let retry = task
+        .retry_config()
+        .expect("authored retry config should be present");
+    assert_eq!(retry.allow(), Some(true));
+    assert_eq!(retry.max_attempts(), Some(3));
+    assert_eq!(retry.delay_ms(), Some(500));
+    let session_verification = task
+        .session_verification_config()
+        .expect("authored session verification should be present");
+    assert_eq!(session_verification.max_attempts(), 3);
+    assert_eq!(session_verification.delay_ms(), 2000);
+}
+
+#[test]
+fn genja_task_compiled_registry_rejects_invalid_task_spec_override() {
+    let error = create_compiled_task_from_spec_str(
+        r#"
+task: acme.tests.derive_runtime.registered_override_metadata_task@1.0.0
+input:
+  options: {}
+overrides:
+  processors: ["audit"]
+"#,
+    )
+    .expect_err("unsupported override should be rejected");
+
+    assert!(matches!(
+        error,
+        genja_core::task::TaskSpecConstructionError::InvalidSpec(
+            genja_core::task::TaskSpecError::InvalidOverride { .. }
+        )
+    ));
 }
 
 #[test]

--- a/genja/examples/task_registration_spec.rs
+++ b/genja/examples/task_registration_spec.rs
@@ -62,6 +62,14 @@ input:
   rules:
     - path: /etc/network
       recursive: true
+overrides:
+  retry:
+    allow: true
+    max_attempts: 2
+    delay_ms: 250
+  session_verification:
+    max_attempts: 2
+    delay_ms: 1000
 "#;
 
     let spec = TaskSpec::parse_auto(yaml_spec)?;
@@ -69,6 +77,21 @@ input:
 
     let yaml_task = create_compiled_task_from_spec_str(yaml_spec)?;
     println!("Created from YAML spec: {}", yaml_task.name());
+    if let Some(retry) = yaml_task.retry_config() {
+        println!(
+            "Retry override: allow={:?} max_attempts={:?} delay_ms={:?}",
+            retry.allow(),
+            retry.max_attempts(),
+            retry.delay_ms()
+        );
+    }
+    if let Some(session_verification) = yaml_task.session_verification_config() {
+        println!(
+            "Session verification override: max_attempts={} delay_ms={}",
+            session_verification.max_attempts(),
+            session_verification.delay_ms()
+        );
+    }
 
     let json_spec = r#"
 {


### PR DESCRIPTION
closes #110 

Adds narrow runtime policy overrides to declarative Rust task specs.

- Supports `overrides.retry`
- Supports `overrides.session_verification`
- Rejects unsupported override fields such as `processors`
- Applies overrides during compiled task construction
- Preserves authored metadata when overrides are omitted
- Updates docs, changelog, and task spec example