### PR TITLE
Feature - 91 macro generated rust task registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changed packages:
 - Added opt-in Rust task registration input schemas with `registration(schema = "schemars")`. Refs: #91
 - Added Rust task registration identity helper APIs for looking up and constructing compiled tasks from `<task-id>@<task-version>` strings. Refs: #91
 - Added runnable Rust examples for task registration schema output and custom factory construction. Refs: #91
+- Added core Rust `TaskSpec` APIs for single-task declarative construction specs with explicit and auto-detected JSON/YAML parsing. Refs: #109
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changed packages:
 - Added core Rust task discovery descriptor types for serializing generated and explicit task registration metadata. Refs: #91
 - Added core Rust task registration identity validation with semver-backed task versions. Refs: #91
 - Added core Rust task catalog and factory registry abstractions with an in-memory implementation for deterministic descriptor lookup and local task construction. Refs: #91
+- Added generated Rust task discovery for `#[genja_task(...)]` tasks through the compiled task registry. Refs: #91
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changed packages:
 - Added Rust task registration identity helper APIs for looking up and constructing compiled tasks from `<task-id>@<task-version>` strings. Refs: #91
 - Added runnable Rust examples for task registration schema output and custom factory construction. Refs: #91
 - Added core Rust `TaskSpec` APIs for single-task declarative construction specs with explicit and auto-detected JSON/YAML parsing and compiled task construction helpers. Refs: #109
+- Added Rust task spec runtime policy overrides for retry and session verification during compiled task construction. Refs: #110
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changed packages:
 - Added core Rust task catalog and factory registry abstractions with an in-memory implementation for deterministic descriptor lookup and local task construction. Refs: #91
 - Added generated Rust task discovery for `#[genja_task(...)]` tasks through the compiled task registry. Refs: #91
 - Added explicit Rust `#[genja_task(..., registration(...))]` task registration with serde-backed JSON construction. Refs: #91
+- Added Rust task registration `default` and `custom(...)` factory strategies for no-input tasks and advanced input preparation. Refs: #91
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changed packages:
 - Added core Rust task registration identity validation with semver-backed task versions. Refs: #91
 - Added core Rust task catalog and factory registry abstractions with an in-memory implementation for deterministic descriptor lookup and local task construction. Refs: #91
 - Added generated Rust task discovery for `#[genja_task(...)]` tasks through the compiled task registry. Refs: #91
+- Added explicit Rust `#[genja_task(..., registration(...))]` task registration with serde-backed JSON construction. Refs: #91
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Changed packages:
 - Added opt-in Rust task registration input schemas with `registration(schema = "schemars")`. Refs: #91
 - Added Rust task registration identity helper APIs for looking up and constructing compiled tasks from `<task-id>@<task-version>` strings. Refs: #91
 - Added runnable Rust examples for task registration schema output and custom factory construction. Refs: #91
-- Added core Rust `TaskSpec` APIs for single-task declarative construction specs with explicit and auto-detected JSON/YAML parsing. Refs: #109
+- Added core Rust `TaskSpec` APIs for single-task declarative construction specs with explicit and auto-detected JSON/YAML parsing and compiled task construction helpers. Refs: #109
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changed packages:
 - Added Rust task registration `default` and `custom(...)` factory strategies for no-input tasks and advanced input preparation. Refs: #91
 - Added opt-in Rust task registration input schemas with `registration(schema = "schemars")`. Refs: #91
 - Added Rust task registration identity helper APIs for looking up and constructing compiled tasks from `<task-id>@<task-version>` strings. Refs: #91
+- Added runnable Rust examples for task registration schema output and custom factory construction. Refs: #91
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Changed packages:
 
 ### Added
 
-- Added core Rust task discovery descriptor types for serializing generated and explicit task registration metadata.
+- Added core Rust task discovery descriptor types for serializing generated and explicit task registration metadata. Refs: #91
+- Added core Rust task registration identity validation with semver-backed task versions. Refs: #91
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed packages:
 
 ### Added
 
+- Added core Rust task discovery descriptor types for serializing generated and explicit task registration metadata.
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changed packages:
 - Added generated Rust task discovery for `#[genja_task(...)]` tasks through the compiled task registry. Refs: #91
 - Added explicit Rust `#[genja_task(..., registration(...))]` task registration with serde-backed JSON construction. Refs: #91
 - Added Rust task registration `default` and `custom(...)` factory strategies for no-input tasks and advanced input preparation. Refs: #91
+- Added opt-in Rust task registration input schemas with `registration(schema = "schemars")`. Refs: #91
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changed packages:
 - Added explicit Rust `#[genja_task(..., registration(...))]` task registration with serde-backed JSON construction. Refs: #91
 - Added Rust task registration `default` and `custom(...)` factory strategies for no-input tasks and advanced input preparation. Refs: #91
 - Added opt-in Rust task registration input schemas with `registration(schema = "schemars")`. Refs: #91
+- Added Rust task registration identity helper APIs for looking up and constructing compiled tasks from `<task-id>@<task-version>` strings. Refs: #91
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changed packages:
 
 - Added core Rust task discovery descriptor types for serializing generated and explicit task registration metadata. Refs: #91
 - Added core Rust task registration identity validation with semver-backed task versions. Refs: #91
+- Added core Rust task catalog and factory registry abstractions with an in-memory implementation for deterministic descriptor lookup and local task construction. Refs: #91
 - Added core Rust dry-run task capability, context, trait, and execution metadata APIs. Refs: #80
 - Added Rust `#[genja_task(...)]` dry-run metadata with `supports_dry_run = true`. Refs: #80
 - Added Rust task idempotency mode metadata with `IdempotencyMode` and `TaskInfo::idempotency_mode()`, defaulting to disabled. Refs: #88

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,8 @@ dependencies = [
  "genja-plugin-manager",
  "log",
  "regex",
+ "schemars",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "semver",
  "syn",
  "trybuild",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "natord",
  "regex",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1314,6 +1315,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "dashmap",
  "genja-core-derive",
  "humantime",
+ "inventory",
  "log",
  "natord",
  "regex",
@@ -719,6 +720,15 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -35,6 +35,7 @@ cargo run -p genja --example run_task_tree
 cargo run -p genja --example async_inventory_plugin
 cargo run -p genja --example task_registration
 cargo run -p genja --example task_registration_custom_factory
+cargo run -p genja --example task_registration_spec
 ```
 
 | Example | Demonstrates |
@@ -47,6 +48,7 @@ cargo run -p genja --example task_registration_custom_factory
 | `async_inventory_plugin.rs` | Implementing an async Rust inventory plugin and building a runtime from generated inventory. |
 | `task_registration.rs` | Registering a Rust task, listing compiled descriptors, printing schema JSON, and constructing by `<id>@<version>`. |
 | `task_registration_custom_factory.rs` | Registering a Rust task with a custom factory for prepared JSON input and sanitized validation errors. |
+| `task_registration_spec.rs` | Constructing a registered Rust task from YAML and JSON task spec strings. |
 
 Use the Rust examples when you want to see the public `genja` crate, the
 `#[genja_task]` macro, and Rust plugin traits in context.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -48,7 +48,7 @@ cargo run -p genja --example task_registration_spec
 | `async_inventory_plugin.rs` | Implementing an async Rust inventory plugin and building a runtime from generated inventory. |
 | `task_registration.rs` | Registering a Rust task, listing compiled descriptors, printing schema JSON, and constructing by `<id>@<version>`. |
 | `task_registration_custom_factory.rs` | Registering a Rust task with a custom factory for prepared JSON input and sanitized validation errors. |
-| `task_registration_spec.rs` | Constructing a registered Rust task from YAML and JSON task spec strings. |
+| `task_registration_spec.rs` | Constructing a registered Rust task from YAML and JSON task spec strings, including retry and session verification overrides. |
 
 Use the Rust examples when you want to see the public `genja` crate, the
 `#[genja_task]` macro, and Rust plugin traits in context.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -33,6 +33,8 @@ cargo run -p genja --example filter_hosts
 cargo run -p genja --example run_task
 cargo run -p genja --example run_task_tree
 cargo run -p genja --example async_inventory_plugin
+cargo run -p genja --example task_registration
+cargo run -p genja --example task_registration_custom_factory
 ```
 
 | Example | Demonstrates |
@@ -43,6 +45,8 @@ cargo run -p genja --example async_inventory_plugin
 | `idempotent_task.rs` | Defining a task-authored convergence check that skips already-converged hosts. |
 | `run_task_tree.rs` | Defining sub-tasks and running a task tree with depth control. |
 | `async_inventory_plugin.rs` | Implementing an async Rust inventory plugin and building a runtime from generated inventory. |
+| `task_registration.rs` | Registering a Rust task, listing compiled descriptors, printing schema JSON, and constructing by `<id>@<version>`. |
+| `task_registration_custom_factory.rs` | Registering a Rust task with a custom factory for prepared JSON input and sanitized validation errors. |
 
 Use the Rust examples when you want to see the public `genja` crate, the
 `#[genja_task]` macro, and Rust plugin traits in context.
@@ -87,4 +91,5 @@ For fuller explanations, see:
 - [Quickstart](quickstart.md)
 - [Inventory](inventory.md)
 - [Tasks](tasks.md)
+- [Rust Task Registration](task-registration.md)
 - [Plugins](plugins/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ the quickstart to load inventory and run your first task.
 - [Concepts](concepts.md)
 - [Inventory](inventory.md)
 - [Tasks](tasks.md)
+- [Rust Task Registration](task-registration.md)
 
 ## Reference
 

--- a/docs/task-registration.md
+++ b/docs/task-registration.md
@@ -257,6 +257,21 @@ Lookup by ID without a version succeeds only when exactly one version exists.
 If multiple versions are registered for the same ID, Genja returns an ambiguous
 version error so callers do not accidentally run the wrong contract.
 
+## Choosing A Construction API
+
+The compiled registry exposes two construction paths. Use the direct registry
+path when application code already has a task identity and JSON value. Use a
+task spec when the caller supplies a YAML or JSON text payload that includes
+both the task identity and input.
+
+| Use case | API |
+| --- | --- |
+| List compiled task descriptors | `list_compiled_tasks()` |
+| Inspect one descriptor by identity | `get_compiled_task_descriptor_by_identity(...)` |
+| Construct from identity plus JSON value | `create_compiled_task_by_identity(...)` |
+| Parse a YAML/JSON task spec without constructing | `TaskSpec::parse_auto(...)` |
+| Construct from a YAML/JSON task spec string | `create_compiled_task_from_spec_str(...)` |
+
 ## Constructing Tasks From JSON
 
 Use `create_compiled_task_by_identity(...)` when the caller supplies JSON input:
@@ -279,6 +294,77 @@ println!("created task {}", task.name());
 Construction returns a `TaskDefinition`. Most task authors do not need to build
 or inspect this wrapper directly; it exists so registry, task-list, and runtime
 APIs can store and execute different task types through one interface.
+
+## Declarative Task Specs
+
+Use `TaskSpec` when the caller supplies a single task invocation as text, such
+as a CLI file, API request, or MCP tool payload. A task spec contains the
+registered task identity and the JSON-compatible input passed to that task's
+factory.
+
+YAML:
+
+```yaml
+task: acme.examples.backup_config@1.0.0
+input:
+  backup_path: /tmp/configs
+  compress: true
+  rules:
+    - path: /etc/network
+      recursive: true
+```
+
+JSON:
+
+```json
+{
+  "task": "acme.examples.backup_config@1.0.0",
+  "input": {
+    "backup_path": "/tmp/configs",
+    "compress": true,
+    "rules": [
+      {
+        "path": "/etc/network",
+        "recursive": true
+      }
+    ]
+  }
+}
+```
+
+Parse a spec without constructing the task when you need to inspect or validate
+the request first:
+
+```rust
+use genja::genja_core::task::TaskSpec;
+
+let spec = TaskSpec::parse_auto(source)?;
+println!("requested task {}", spec.task);
+```
+
+Construct directly from a spec string when the caller wants the registered task:
+
+```rust
+use genja::genja_core::task::{TaskInfo, create_compiled_task_from_spec_str};
+
+let task = create_compiled_task_from_spec_str(source)?;
+println!("created task {}", task.name());
+```
+
+`parse_auto(...)` tries JSON first, then YAML. If neither parser accepts the
+input, Genja returns an auto-parse error that includes both parser messages. If
+the text parses but is not an object with `task` and optional `input`, Genja
+returns a task-spec shape error instead of treating it as a registry failure.
+
+This is a single-task construction spec. It is not a workflow DSL, task list,
+or execution override model. Future work can build those features on top of the
+same registered task identity and JSON-compatible input contract.
+
+Run the complete task spec example from the repository root:
+
+```bash
+cargo run -p genja --example task_registration_spec
+```
 
 ## Default Factory
 
@@ -396,8 +482,12 @@ the Rust registration path.
 
 ## Related Examples
 
-- `genja/examples/task_registration.rs`
-- `genja/examples/task_registration_custom_factory.rs`
+- `genja/examples/task_registration.rs` shows the baseline registration,
+  descriptor listing, schema, and direct construction path.
+- `genja/examples/task_registration_custom_factory.rs` shows a custom factory
+  for prepared JSON input and sanitized validation errors.
+- `genja/examples/task_registration_spec.rs` shows YAML/JSON task spec parsing
+  and construction.
 
 ## Related Guides
 

--- a/docs/task-registration.md
+++ b/docs/task-registration.md
@@ -520,8 +520,8 @@ the Rust registration path.
   descriptor listing, schema, and direct construction path.
 - `genja/examples/task_registration_custom_factory.rs` shows a custom factory
   for prepared JSON input and sanitized validation errors.
-- `genja/examples/task_registration_spec.rs` shows YAML/JSON task spec parsing
-  and construction.
+- `genja/examples/task_registration_spec.rs` shows YAML/JSON task spec parsing,
+  construction, and retry/session verification overrides.
 
 ## Related Guides
 

--- a/docs/task-registration.md
+++ b/docs/task-registration.md
@@ -299,8 +299,8 @@ APIs can store and execute different task types through one interface.
 
 Use `TaskSpec` when the caller supplies a single task invocation as text, such
 as a CLI file, API request, or MCP tool payload. A task spec contains the
-registered task identity and the JSON-compatible input passed to that task's
-factory.
+registered task identity, the JSON-compatible input passed to that task's
+factory, and optional runtime policy overrides.
 
 YAML:
 
@@ -312,6 +312,14 @@ input:
   rules:
     - path: /etc/network
       recursive: true
+overrides:
+  retry:
+    allow: true
+    max_attempts: 3
+    delay_ms: 500
+  session_verification:
+    max_attempts: 2
+    delay_ms: 1000
 ```
 
 JSON:
@@ -328,6 +336,17 @@ JSON:
         "recursive": true
       }
     ]
+  },
+  "overrides": {
+    "retry": {
+      "allow": true,
+      "max_attempts": 3,
+      "delay_ms": 500
+    },
+    "session_verification": {
+      "max_attempts": 2,
+      "delay_ms": 1000
+    }
   }
 }
 ```
@@ -353,12 +372,27 @@ println!("created task {}", task.name());
 
 `parse_auto(...)` tries JSON first, then YAML. If neither parser accepts the
 input, Genja returns an auto-parse error that includes both parser messages. If
-the text parses but is not an object with `task` and optional `input`, Genja
-returns a task-spec shape error instead of treating it as a registry failure.
+the text parses but is not an object with `task`, optional `input`, and optional
+`overrides`, Genja returns a task-spec shape error instead of treating it as a
+registry failure.
 
-This is a single-task construction spec. It is not a workflow DSL, task list,
-or execution override model. Future work can build those features on top of the
-same registered task identity and JSON-compatible input contract.
+Overrides are narrow per-run runtime policy controls. The first supported
+fields are:
+
+| Override | Effect |
+| --- | --- |
+| `retry` | Overrides the constructed task's retry policy for this run. |
+| `session_verification` | Overrides post-change session verification policy for this run. |
+
+Overrides do not rewrite authored task behavior. The spec intentionally does
+not support overriding processors, connection plugin names, execution mode,
+task identity, factory strategy, schema, or registration metadata. In
+particular, processor overrides are rejected because processors can affect
+startup hooks, result handling, and side effects selected by the task author.
+
+This is a single-task construction spec. It is not a workflow DSL or task list.
+Future work can build those features on top of the same registered task
+identity and JSON-compatible input contract.
 
 Run the complete task spec example from the repository root:
 

--- a/docs/task-registration.md
+++ b/docs/task-registration.md
@@ -1,0 +1,406 @@
+# Rust Task Registration
+
+Task registration lets Rust applications discover and construct tasks that were
+compiled into the process. It is the first layer of Genja's task catalog model:
+CLIs, MCP servers, provider manifests, and future remote catalogs can inspect a
+task descriptor before deciding whether to construct and run the task.
+
+Registration is opt-in. Existing Rust tasks that use `#[genja_task(...)]`
+without `registration(...)` continue to work as normal runtime tasks.
+
+## When To Use Registration
+
+Use registration when a task should be addressable by a stable catalog identity
+instead of by directly constructing the Rust struct in application code.
+
+Registration is useful for:
+
+- listing tasks compiled into an application
+- looking up task metadata by ID and version
+- showing input schemas to a CLI, UI, or MCP client
+- constructing a task from JSON input
+- exporting descriptor metadata into future provider manifests
+
+Direct construction is still the simplest path when the caller already knows
+the Rust type:
+
+```rust
+let task = BackupConfig {
+    backup_path: "/tmp/configs".to_string(),
+    compress: true,
+};
+```
+
+Registration is the API-style path when the caller knows a task identity and
+has JSON-compatible input:
+
+```rust
+let task = create_compiled_task_by_identity(
+    "acme.examples.backup_config@1.0.0",
+    serde_json::json!({
+        "backup_path": "/tmp/configs",
+        "compress": true,
+        "rules": []
+    }),
+)?;
+```
+
+## Discovery And Stable IDs
+
+Every Rust task annotated with `#[genja_task(...)]` is submitted to the compiled
+task registry.
+
+Tasks without explicit registration receive a generated ID:
+
+```text
+auto:<rust-type-path>
+```
+
+Generated IDs are useful for local discovery, but they are derived from Rust
+implementation details and should not be treated as stable public contracts.
+Renaming a type or moving a module can change the generated ID.
+
+Registered tasks use an explicit stable ID:
+
+```rust
+#[genja_task(
+    name = "backup_config",
+    registration(id = "acme.examples.backup_config")
+)]
+impl BackupConfig {
+    // task methods
+}
+```
+
+The public identity is:
+
+```text
+<task-id>@<task-version>
+```
+
+For example:
+
+```text
+acme.examples.backup_config@1.0.0
+```
+
+Task IDs are namespace-friendly lowercase identifiers made of `.` separated
+segments. Versions must be semantic versions. If `version` is omitted, the
+macro uses the provider crate version from `CARGO_PKG_VERSION`.
+
+Duplicate `id + version` registrations return a deterministic registry error
+when the compiled registry is built.
+
+## Default JSON Construction
+
+The default factory for registered Rust tasks is serde deserialization. When
+`factory` is omitted, Genja treats the JSON input passed to the registry as the
+task struct's construction input. The JSON object must match the task fields.
+
+```rust
+use genja::genja_core::inventory::Host;
+use genja::genja_core::task::{
+    HostTaskResult, TaskError, TaskRuntimeContext, TaskSuccess,
+};
+use genja::genja_task;
+
+#[derive(serde::Deserialize)]
+struct BackupConfig {
+    backup_path: String,
+    compress: bool,
+}
+
+#[genja_task(
+    name = "backup_config",
+    connection_plugin_name = "ssh",
+    registration(
+        id = "acme.examples.backup_config",
+        version = "1.0.0",
+        description = "Backs up selected paths from a network device"
+    )
+)]
+impl BackupConfig {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, TaskError> {
+        Ok(HostTaskResult::passed(
+            TaskSuccess::new().with_summary(format!(
+                "backing up to {} compress={}",
+                self.backup_path,
+                self.compress
+            )),
+        ))
+    }
+}
+```
+
+With this task registered, a caller can construct it from JSON:
+
+```rust
+use genja::genja_core::task::{TaskInfo, create_compiled_task_by_identity};
+use serde_json::json;
+
+let task = create_compiled_task_by_identity(
+    "acme.examples.backup_config@1.0.0",
+    json!({
+        "backup_path": "/tmp/configs",
+        "compress": true
+    }),
+)?;
+
+assert_eq!(task.name(), "backup_config");
+```
+
+The input:
+
+```json
+{
+  "backup_path": "/tmp/configs",
+  "compress": true
+}
+```
+
+maps directly to the task struct:
+
+```rust
+BackupConfig {
+    backup_path: "/tmp/configs".to_string(),
+    compress: true,
+}
+```
+
+The registry returns a `TaskDefinition`, which is Genja's runtime wrapper around
+the constructed task. Conceptually, the factory result is:
+
+```rust
+TaskDefinition::new(BackupConfig {
+    backup_path: "/tmp/configs".to_string(),
+    compress: true,
+})
+```
+
+This is the normal path when the public JSON input has the same shape as the
+Rust task struct. The task type must implement
+`serde::de::DeserializeOwned`. Nested input types must be deserializable too.
+If the JSON does not match the struct fields, construction fails with
+`TaskRegistrationError::InvalidInput`.
+
+## Input Schemas
+
+Add `schema = "schemars"` when callers should be able to inspect the expected
+JSON input shape.
+
+```rust
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct BackupConfig {
+    backup_path: String,
+    compress: bool,
+}
+
+#[genja_task(
+    name = "backup_config",
+    registration(
+        id = "acme.examples.backup_config",
+        schema = "schemars"
+    )
+)]
+impl BackupConfig {
+    // task methods
+}
+```
+
+`schema = "schemars"` requires the task type and any nested input types to
+implement `schemars::JsonSchema`.
+
+The generated schema is stored in `TaskDescriptor::input_schema`:
+
+```rust
+let descriptor =
+    get_compiled_task_descriptor_by_identity("acme.examples.backup_config@1.0.0")?;
+
+if let Some(schema) = descriptor.input_schema {
+    println!("{}", serde_json::to_string_pretty(&schema)?);
+}
+```
+
+Run the complete schema example from the repository root:
+
+```bash
+cargo run -p genja --example task_registration
+```
+
+## Listing And Looking Up Tasks
+
+Use `list_compiled_tasks()` when you need a local task list:
+
+```rust
+use genja::genja_core::task::list_compiled_tasks;
+
+for descriptor in list_compiled_tasks()? {
+    println!("{}@{} {}", descriptor.id, descriptor.version, descriptor.name);
+}
+```
+
+Use identity-based lookup when a CLI, API, or MCP tool receives a single task
+identity string:
+
+```rust
+use genja::genja_core::task::get_compiled_task_descriptor_by_identity;
+
+let descriptor =
+    get_compiled_task_descriptor_by_identity("acme.examples.backup_config@1.0.0")?;
+```
+
+Lookup by ID without a version succeeds only when exactly one version exists.
+If multiple versions are registered for the same ID, Genja returns an ambiguous
+version error so callers do not accidentally run the wrong contract.
+
+## Constructing Tasks From JSON
+
+Use `create_compiled_task_by_identity(...)` when the caller supplies JSON input:
+
+```rust
+use genja::genja_core::task::{TaskInfo, create_compiled_task_by_identity};
+use serde_json::json;
+
+let task = create_compiled_task_by_identity(
+    "acme.examples.backup_config@1.0.0",
+    json!({
+        "backup_path": "/tmp/configs",
+        "compress": true
+    }),
+)?;
+
+println!("created task {}", task.name());
+```
+
+Construction returns a `TaskDefinition`. Most task authors do not need to build
+or inspect this wrapper directly; it exists so registry, task-list, and runtime
+APIs can store and execute different task types through one interface.
+
+## Default Factory
+
+Use `factory = "default"` for registered tasks that do not accept input:
+
+```rust
+#[derive(Default)]
+struct CollectFacts;
+
+#[genja_task(
+    name = "collect_facts",
+    registration(
+        id = "acme.examples.collect_facts",
+        factory = "default"
+    )
+)]
+impl CollectFacts {
+    // task methods
+}
+```
+
+The task type must implement `Default`. Callers must pass `null` or `{}` as
+construction input.
+
+## Custom Factory
+
+Use `factory = custom(path)` when the public JSON input should differ from the
+task struct or when construction requires input preparation.
+
+```rust
+use genja::genja_core::task::TaskRegistrationError;
+use serde_json::Value;
+
+struct ConfigureAcl {
+    acl_name: String,
+    secret_token: String,
+}
+
+fn create_configure_acl(input: Value) -> Result<ConfigureAcl, TaskRegistrationError> {
+    let acl_name = input
+        .get("acl")
+        .and_then(Value::as_str)
+        .ok_or_else(|| TaskRegistrationError::InvalidInput {
+            id: "acme.examples.configure_acl".to_string(),
+            version: "1.0.0".to_string(),
+            message: "`acl` is required".to_string(),
+        })?;
+
+    let token_obfuscated = input
+        .get("token_obfuscated")
+        .and_then(Value::as_str)
+        .ok_or_else(|| TaskRegistrationError::InvalidInput {
+            id: "acme.examples.configure_acl".to_string(),
+            version: "1.0.0".to_string(),
+            message: "`token_obfuscated` is required".to_string(),
+        })?;
+
+    Ok(ConfigureAcl {
+        acl_name: acl_name.to_string(),
+        secret_token: token_obfuscated.chars().rev().collect(),
+    })
+}
+```
+
+Then reference the function from the task macro:
+
+```rust
+#[genja_task(
+    name = "configure_acl",
+    registration(
+        id = "acme.examples.configure_acl",
+        version = "1.0.0",
+        factory = custom(create_configure_acl)
+    )
+)]
+impl ConfigureAcl {
+    // task methods
+}
+```
+
+Custom factories should return sanitized errors. Identify the affected task and
+field, but do not include raw input values or decoded secret material in error
+messages.
+
+Run the complete custom factory example from the repository root:
+
+```bash
+cargo run -p genja --example task_registration_custom_factory
+```
+
+## Descriptor JSON
+
+Descriptors serialize to JSON for future provider manifests, remote catalogs,
+and MCP tooling:
+
+```json
+{
+  "id": "acme.examples.backup_config",
+  "id_source": "explicit",
+  "name": "backup_config",
+  "version": "1.0.0",
+  "description": "Backs up selected paths from a network device",
+  "execution_mode": "async",
+  "connection_plugin_name": "ssh",
+  "processor_names": [],
+  "retry": null,
+  "input_schema": null,
+  "constructible": true
+}
+```
+
+The exact descriptor contract is shared by future Rust and Python registration
+work. Python task registration is planned separately; today this guide covers
+the Rust registration path.
+
+## Related Examples
+
+- `genja/examples/task_registration.rs`
+- `genja/examples/task_registration_custom_factory.rs`
+
+## Related Guides
+
+- [Tasks](tasks.md)
+- [Examples](examples.md)
+- [API Surface](api-surface.md)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -107,6 +107,10 @@ use genja::genja_task;
 
 The macro applies to an inherent `impl` block. It generates the task metadata
 and the `Task` implementation from the methods and attributes on that block.
+Most task authors work with the task struct and `#[genja_task]` implementation
+directly. `TaskDefinition` is Genja's runtime wrapper around a task instance; it
+is mainly used by registry, task-list, and lower-level runtime APIs rather than
+ordinary task authoring code.
 
 ```rust
 use genja::genja_core::inventory::Host;
@@ -181,6 +185,9 @@ Define exactly one task entrypoint in the macro `impl` block:
 The macro can also read optional helper methods from the same `impl` block, such
 as `options(...)` and `sub_tasks(...)`. Use those helpers when a task needs
 dynamic JSON options or child tasks in a task tree.
+
+For stable discovery and JSON construction by task ID, see
+[Rust Task Registration](task-registration.md).
 
 ### Rust Retry Overrides
 

--- a/genja-core-derive/Cargo.toml
+++ b/genja-core-derive/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools", "rust-patterns"]
 [dependencies]
 proc-macro2 = "1.0.101"
 quote = "1.0.40"
+semver = "1.0.23"
 syn = { version = "2.0.106", features = ["full"] }
 
 [dev-dependencies]

--- a/genja-core-derive/src/lib.rs
+++ b/genja-core-derive/src/lib.rs
@@ -4,10 +4,11 @@
 //! implementations for tuple-wrapper types.
 //!
 //! `genja_task` is the public task-authoring macro. It generates both
-//! `TaskInfo` and `Task` implementations from an inherent `impl` block and
-//! infers execution mode from `fn start(...)` versus `async fn start_async(...)`.
-//! The optional `retry(...)` block emits static `genja_core::task::RetryConfig`
-//! metadata for task-level retry overrides.
+//! `TaskInfo` and `Task` implementations from an inherent `impl` block, submits
+//! local discovery metadata to the compiled task registry, and infers execution
+//! mode from `fn start(...)` versus `async fn start_async(...)`. The optional
+//! `retry(...)` block emits static `genja_core::task::RetryConfig` metadata for
+//! task-level retry overrides.
 //!
 //! # Task Authoring Example
 //! ```ignore
@@ -152,8 +153,8 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-/// Generate `TaskInfo` and `Task` implementations for an inherent task `impl`
-/// block.
+/// Generate `TaskInfo`, `Task`, and local discovery metadata for an inherent
+/// task `impl` block.
 ///
 /// The macro requires `name = "..."` and exactly one task entrypoint:
 /// `fn start(...)` for blocking tasks or `async fn start_async(...)` for async
@@ -169,6 +170,10 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 /// - `session_verification(max_attempts = ..., delay_ms = ...)`; defaults to
 ///   disabled when the block is absent. Inside the block, omitted
 ///   `max_attempts` defaults to `1` and omitted `delay_ms` defaults to `0`.
+///
+/// Every annotated task is discoverable through the compiled task registry with
+/// a generated local-only ID derived from the Rust type path. Generated
+/// discovery metadata does not make the task constructible from JSON input.
 ///
 /// `session_verification(...)` requires `connection_plugin_name = "..."`,
 /// because post-change session verification must replace a declared task
@@ -711,7 +716,7 @@ fn expand_genja_task(
         ));
     }
 
-    let connection_impl = match connection_plugin_name {
+    let connection_impl = match &connection_plugin_name {
         Some(plugin_name) => quote! { Some(#plugin_name) },
         None => quote! { None },
     };
@@ -746,23 +751,27 @@ fn expand_genja_task(
         }
     };
 
-    let retry_config_impl = if let Some(retry) = retry {
+    let retry_config_value = retry.as_ref().map(|retry| {
         let allow = match retry.allow {
-            Some(allow) => quote! { Some(#allow) },
+            Some(ref allow) => quote! { Some(#allow) },
             None => quote! { None },
         };
         let max_attempts = match retry.max_attempts {
-            Some(max_attempts) => quote! { Some(#max_attempts) },
+            Some(ref max_attempts) => quote! { Some(#max_attempts) },
             None => quote! { None },
         };
         let delay_ms = match retry.delay_ms {
-            Some(delay_ms) => quote! { Some(#delay_ms) },
+            Some(ref delay_ms) => quote! { Some(#delay_ms) },
             None => quote! { None },
         };
+        quote! { genja_core::task::RetryConfig::new(#allow, #max_attempts, #delay_ms) }
+    });
+
+    let retry_config_impl = if let Some(retry_config_value) = &retry_config_value {
         quote! {
             fn retry_config(&self) -> Option<&genja_core::task::RetryConfig> {
                 static RETRY_CONFIG: genja_core::task::RetryConfig =
-                    genja_core::task::RetryConfig::new(#allow, #max_attempts, #delay_ms);
+                    #retry_config_value;
                 Some(&RETRY_CONFIG)
             }
         }
@@ -822,6 +831,43 @@ fn expand_genja_task(
         quote! {}
     };
 
+    let execution_mode = if has_start {
+        quote! { genja_core::task::TaskExecutionMode::Blocking }
+    } else {
+        quote! { genja_core::task::TaskExecutionMode::Async }
+    };
+
+    let descriptor_connection_plugin_name = match &connection_plugin_name {
+        Some(plugin_name) => quote! { Some(#plugin_name.to_string()) },
+        None => quote! { None },
+    };
+    let descriptor_retry = match &retry_config_value {
+        Some(retry_config_value) => quote! { Some(#retry_config_value) },
+        None => quote! { None },
+    };
+    let descriptor_registration = quote! {
+        const _: () = {
+            fn __genja_task_descriptor() -> genja_core::task::TaskDescriptor {
+                genja_core::task::TaskDescriptor::generated(
+                    format!("auto:{}", std::any::type_name::<#self_ty>()),
+                    env!("CARGO_PKG_VERSION"),
+                    genja_core::task::TaskDescriptorMetadata {
+                        name: #name.to_string(),
+                        description: None,
+                        execution_mode: #execution_mode,
+                        connection_plugin_name: #descriptor_connection_plugin_name,
+                        processor_names: vec![#(#processors.to_string()),*],
+                        retry: #descriptor_retry,
+                    },
+                )
+            }
+
+            genja_core::__inventory::submit! {
+                genja_core::task::CompiledTaskRegistration::descriptor_only(__genja_task_descriptor)
+            }
+        };
+    };
+
     let task_impl = if has_start {
         let dry_run_impl = if has_dry_run {
             quote! {
@@ -867,7 +913,7 @@ fn expand_genja_task(
                 #sub_tasks_impl
 
                 fn execution_mode(&self) -> genja_core::task::TaskExecutionMode {
-                    genja_core::task::TaskExecutionMode::Blocking
+                    #execution_mode
                 }
             }
         }
@@ -916,7 +962,7 @@ fn expand_genja_task(
                 #sub_tasks_impl
 
                 fn execution_mode(&self) -> genja_core::task::TaskExecutionMode {
-                    genja_core::task::TaskExecutionMode::Async
+                    #execution_mode
                 }
             }
         }
@@ -948,6 +994,8 @@ fn expand_genja_task(
         }
 
         #task_impl
+
+        #descriptor_registration
     })
 }
 

--- a/genja-core-derive/src/lib.rs
+++ b/genja-core-derive/src/lib.rs
@@ -7,8 +7,8 @@
 //! `TaskInfo` and `Task` implementations from an inherent `impl` block, submits
 //! local discovery metadata to the compiled task registry, and infers execution
 //! mode from `fn start(...)` versus `async fn start_async(...)`. The optional
-//! `registration(...)` block gives a task a stable catalog ID and JSON
-//! construction factory.
+//! `registration(...)` block gives a task a stable catalog ID and local JSON
+//! construction factory for CLI, MCP, provider manifest, and catalog workflows.
 //!
 //! # Task Authoring Example
 //! ```ignore
@@ -177,6 +177,20 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 ///   descriptor. Schema generation requires the task type, and any nested field
 ///   types, to implement `schemars::JsonSchema`.
 ///
+/// # Discovery and registration
+///
+/// Every annotated task is submitted to the compiled task registry. Tasks
+/// without `registration(...)` use a generated `auto:...` ID derived from the
+/// Rust type path. Generated IDs are useful for local listing, but they are not
+/// stable public contracts and are not constructible from JSON input.
+///
+/// Tasks with `registration(id = "...")` use an explicit stable ID. Their
+/// public identity is `<task-id>@<task-version>`, for example
+/// `acme.network.configure_acl@2.0.0`. Explicit IDs are validated as
+/// namespace-friendly lowercase identifiers and versions are validated as
+/// semantic versions. Duplicate `id + version` registrations are rejected when
+/// the compiled registry is built.
+///
 /// Registered tasks support three construction strategies:
 ///
 /// - Omit `factory` or use `factory = "serde"` to deserialize JSON input into
@@ -195,11 +209,6 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 /// factory accepts a public JSON shape that differs from the task struct, omit
 /// schema generation for now or keep the custom input contract documented
 /// separately until a dedicated input-type schema option is added.
-///
-/// Every annotated task is discoverable through the compiled task registry with
-/// either an explicit stable ID from `registration(...)` or a generated
-/// local-only ID derived from the Rust type path. Generated discovery metadata
-/// does not make the task constructible from JSON input.
 ///
 /// `session_verification(...)` requires `connection_plugin_name = "..."`,
 /// because post-change session verification must replace a declared task
@@ -231,6 +240,41 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
+/// The default registered-task path uses serde construction. This is the
+/// common path for tasks that should be created from user-provided JSON input.
+///
+/// ```ignore
+/// use genja_core::genja_task;
+/// use genja_core::inventory::Host;
+/// use genja_core::task::{HostTaskResult, TaskRuntimeContext, TaskSuccess};
+///
+/// #[derive(serde::Deserialize)]
+/// struct BackupConfig {
+///     backup_path: String,
+///     compress: bool,
+/// }
+///
+/// #[genja_task(
+///     name = "backup_config",
+///     connection_plugin_name = "ssh",
+///     registration(id = "acme.backup.backup_config")
+/// )]
+/// impl BackupConfig {
+///     async fn start_async(
+///         &self,
+///         _host: &Host,
+///         _context: &TaskRuntimeContext,
+///     ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+///         Ok(HostTaskResult::passed(
+///             TaskSuccess::new().with_summary(format!(
+///                 "backing up to {}",
+///                 self.backup_path
+///             )),
+///         ))
+///     }
+/// }
+/// ```
+///
 /// ```ignore
 /// use genja_core::genja_task;
 /// use genja_core::inventory::Host;
@@ -251,6 +295,35 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 ///     )
 /// )]
 /// impl ConfigureAcl {
+///     async fn start_async(
+///         &self,
+///         _host: &Host,
+///         _context: &TaskRuntimeContext,
+///     ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+///         Ok(HostTaskResult::passed(TaskSuccess::new()))
+///     }
+/// }
+/// ```
+///
+/// No-input tasks can use the default factory. The task type must implement
+/// `Default`, and callers must pass `null` or `{}` as construction input.
+///
+/// ```ignore
+/// use genja_core::genja_task;
+/// use genja_core::inventory::Host;
+/// use genja_core::task::{HostTaskResult, TaskRuntimeContext, TaskSuccess};
+///
+/// #[derive(Default)]
+/// struct CollectFacts;
+///
+/// #[genja_task(
+///     name = "collect_facts",
+///     registration(
+///         id = "acme.inventory.collect_facts",
+///         factory = "default"
+///     )
+/// )]
+/// impl CollectFacts {
 ///     async fn start_async(
 ///         &self,
 ///         _host: &Host,

--- a/genja-core-derive/src/lib.rs
+++ b/genja-core-derive/src/lib.rs
@@ -7,8 +7,8 @@
 //! `TaskInfo` and `Task` implementations from an inherent `impl` block, submits
 //! local discovery metadata to the compiled task registry, and infers execution
 //! mode from `fn start(...)` versus `async fn start_async(...)`. The optional
-//! `retry(...)` block emits static `genja_core::task::RetryConfig` metadata for
-//! task-level retry overrides.
+//! `registration(...)` block gives a task a stable catalog ID and serde-backed
+//! JSON construction factory.
 //!
 //! # Task Authoring Example
 //! ```ignore
@@ -170,10 +170,17 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 /// - `session_verification(max_attempts = ..., delay_ms = ...)`; defaults to
 ///   disabled when the block is absent. Inside the block, omitted
 ///   `max_attempts` defaults to `1` and omitted `delay_ms` defaults to `0`.
+/// - `registration(id = "...", version = "...", description = "...")`; opts
+///   into stable task registration and JSON construction. `id` is required,
+///   `version` defaults to `env!("CARGO_PKG_VERSION")`, and `factory = "serde"`
+///   may be supplied explicitly but is the default and only supported factory
+///   for this phase. Registered task types must implement
+///   `serde::de::DeserializeOwned`.
 ///
 /// Every annotated task is discoverable through the compiled task registry with
-/// a generated local-only ID derived from the Rust type path. Generated
-/// discovery metadata does not make the task constructible from JSON input.
+/// either an explicit stable ID from `registration(...)` or a generated
+/// local-only ID derived from the Rust type path. Generated discovery metadata
+/// does not make the task constructible from JSON input.
 ///
 /// `session_verification(...)` requires `connection_plugin_name = "..."`,
 /// because post-change session verification must replace a declared task
@@ -204,6 +211,35 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
+///
+/// ```ignore
+/// use genja_core::genja_task;
+/// use genja_core::inventory::Host;
+/// use genja_core::task::{HostTaskResult, TaskRuntimeContext, TaskSuccess};
+///
+/// #[derive(serde::Deserialize)]
+/// struct ConfigureAcl {
+///     acl_name: String,
+/// }
+///
+/// #[genja_task(
+///     name = "configure_acl",
+///     registration(
+///         id = "acme.network.configure_acl",
+///         version = "2.0.0",
+///         description = "Configures an ACL on a network device"
+///     )
+/// )]
+/// impl ConfigureAcl {
+///     async fn start_async(
+///         &self,
+///         _host: &Host,
+///         _context: &TaskRuntimeContext,
+///     ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+///         Ok(HostTaskResult::passed(TaskSuccess::new()))
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn genja_task(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as GenjaTaskArgs);
@@ -223,6 +259,7 @@ struct GenjaTaskArgs {
     idempotency: Option<IdempotencyModeArg>,
     processors: Vec<LitStr>,
     retry: Option<RetryArgs>,
+    registration: Option<RegistrationArgs>,
     session_verification: Option<SessionVerificationArgs>,
 }
 
@@ -244,6 +281,14 @@ struct RetryArgs {
     allow: Option<LitBool>,
     max_attempts: Option<LitInt>,
     delay_ms: Option<LitInt>,
+}
+
+#[derive(Default)]
+struct RegistrationArgs {
+    id: Option<LitStr>,
+    version: Option<LitStr>,
+    description: Option<LitStr>,
+    factory: Option<LitStr>,
 }
 
 #[derive(Default)]
@@ -320,6 +365,14 @@ impl Parse for GenjaTaskArgs {
                     parenthesized!(content in input);
                     args.retry = Some(content.parse()?);
                 }
+                "registration" => {
+                    if args.registration.is_some() {
+                        return Err(syn::Error::new_spanned(key, "duplicate `registration`"));
+                    }
+                    let content;
+                    parenthesized!(content in input);
+                    args.registration = Some(content.parse()?);
+                }
                 "session_verification" => {
                     if args.session_verification.is_some() {
                         return Err(syn::Error::new_spanned(
@@ -334,7 +387,7 @@ impl Parse for GenjaTaskArgs {
                 _ => {
                     return Err(syn::Error::new_spanned(
                         key,
-                        "unsupported key; expected `name`, `connection_plugin_name`, `supports_dry_run`, `idempotency`, `processors`, `retry(...)`, or `session_verification(...)`",
+                        "unsupported key; expected `name`, `connection_plugin_name`, `supports_dry_run`, `idempotency`, `processors`, `retry(...)`, `registration(...)`, or `session_verification(...)`",
                     ));
                 }
             }
@@ -392,6 +445,148 @@ fn parse_idempotency_mode_expr(expr: &Expr) -> syn::Result<IdempotencyModeArg> {
             "`idempotency` must be IdempotencyMode::Disabled, IdempotencyMode::Check, or IdempotencyMode::CheckAndVerify",
         )),
     }
+}
+
+impl Parse for RegistrationArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut args = Self::default();
+
+        while !input.is_empty() {
+            let key: syn::Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            match key.to_string().as_str() {
+                "id" => {
+                    if args.id.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "duplicate registration key `id`",
+                        ));
+                    }
+                    let id: LitStr = input.parse()?;
+                    validate_registration_id_literal(&id)?;
+                    args.id = Some(id);
+                }
+                "version" => {
+                    if args.version.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "duplicate registration key `version`",
+                        ));
+                    }
+                    let version: LitStr = input.parse()?;
+                    validate_registration_version_literal(&version)?;
+                    args.version = Some(version);
+                }
+                "description" => {
+                    if args.description.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "duplicate registration key `description`",
+                        ));
+                    }
+                    args.description = Some(input.parse()?);
+                }
+                "factory" => {
+                    if args.factory.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "duplicate registration key `factory`",
+                        ));
+                    }
+                    let factory: LitStr = input.parse()?;
+                    if factory.value() != "serde" {
+                        return Err(syn::Error::new_spanned(
+                            factory,
+                            "`registration(factory = ...)` currently supports only `\"serde\"`; omit `factory` to use serde",
+                        ));
+                    }
+                    args.factory = Some(factory);
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        key,
+                        "unsupported registration key; expected `id`, `version`, `description`, or `factory`",
+                    ));
+                }
+            }
+
+            if input.is_empty() {
+                break;
+            }
+
+            input.parse::<Token![,]>()?;
+        }
+
+        if args.id.is_none() {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "`registration(...)` requires `id = \"...\"`",
+            ));
+        }
+
+        Ok(args)
+    }
+}
+
+fn validate_registration_id_literal(id: &LitStr) -> syn::Result<()> {
+    let value = id.value();
+    let invalid =
+        |reason: &str| syn::Error::new_spanned(id, format!("invalid registration `id`: {reason}"));
+
+    if value.is_empty() {
+        return Err(invalid("id must not be empty"));
+    }
+
+    if value.trim() != value {
+        return Err(invalid("id must not have leading or trailing whitespace"));
+    }
+
+    if value.contains('@') {
+        return Err(invalid("id must not contain `@`"));
+    }
+
+    for segment in value.split('.') {
+        if segment.is_empty() {
+            return Err(invalid("id segments must not be empty"));
+        }
+
+        let first = segment
+            .bytes()
+            .next()
+            .expect("segment is known to be non-empty");
+        if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+            return Err(invalid(
+                "id segments must start with an ASCII lowercase letter or digit",
+            ));
+        }
+
+        if !segment.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' || byte == b'-'
+        }) {
+            return Err(invalid(
+                "id segments may contain only ASCII lowercase letters, digits, `_`, or `-`",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_registration_version_literal(version: &LitStr) -> syn::Result<()> {
+    let value = version.value();
+    if value.is_empty() {
+        return Err(syn::Error::new_spanned(
+            version,
+            "invalid registration `version`: version must not be empty",
+        ));
+    }
+
+    semver::Version::parse(&value).map_err(|error| {
+        syn::Error::new_spanned(version, format!("invalid registration `version`: {error}"))
+    })?;
+
+    Ok(())
 }
 
 impl Parse for RetryArgs {
@@ -707,6 +902,7 @@ fn expand_genja_task(
     let connection_plugin_name = args.connection_plugin_name;
     let processors = args.processors;
     let retry = args.retry;
+    let registration = args.registration;
     let session_verification = args.session_verification;
 
     if session_verification.is_some() && connection_plugin_name.is_none() {
@@ -723,7 +919,7 @@ fn expand_genja_task(
 
     let options_impl = if has_options {
         quote! {
-            fn options(&self) -> Option<&serde_json::Value> {
+            fn options(&self) -> Option<&genja_core::__serde_json::Value> {
                 #self_ty::options(self)
             }
         }
@@ -845,27 +1041,81 @@ fn expand_genja_task(
         Some(retry_config_value) => quote! { Some(#retry_config_value) },
         None => quote! { None },
     };
-    let descriptor_registration = quote! {
-        const _: () = {
-            fn __genja_task_descriptor() -> genja_core::task::TaskDescriptor {
-                genja_core::task::TaskDescriptor::generated(
-                    format!("auto:{}", std::any::type_name::<#self_ty>()),
-                    env!("CARGO_PKG_VERSION"),
-                    genja_core::task::TaskDescriptorMetadata {
-                        name: #name.to_string(),
-                        description: None,
-                        execution_mode: #execution_mode,
-                        connection_plugin_name: #descriptor_connection_plugin_name,
-                        processor_names: vec![#(#processors.to_string()),*],
-                        retry: #descriptor_retry,
-                    },
-                )
-            }
-
-            genja_core::__inventory::submit! {
-                genja_core::task::CompiledTaskRegistration::descriptor_only(__genja_task_descriptor)
-            }
+    let descriptor_registration = if let Some(registration) = &registration {
+        let registration_id = registration.id.as_ref().expect("validated by parser");
+        let registration_version = match &registration.version {
+            Some(version) => quote! { #version },
+            None => quote! { env!("CARGO_PKG_VERSION") },
         };
+        let registration_description = match &registration.description {
+            Some(description) => quote! { Some(#description.to_string()) },
+            None => quote! { None },
+        };
+
+        quote! {
+            const _: () = {
+                fn __genja_task_descriptor() -> genja_core::task::TaskDescriptor {
+                    genja_core::task::TaskDescriptor::explicit(
+                        #registration_id,
+                        #registration_version,
+                        genja_core::task::TaskDescriptorMetadata {
+                            name: #name.to_string(),
+                            description: #registration_description,
+                            execution_mode: #execution_mode,
+                            connection_plugin_name: #descriptor_connection_plugin_name,
+                            processor_names: vec![#(#processors.to_string()),*],
+                            retry: #descriptor_retry,
+                        },
+                        None,
+                        true,
+                    )
+                }
+
+                fn __genja_task_create(
+                    input: genja_core::__serde_json::Value,
+                ) -> Result<genja_core::task::TaskDefinition, genja_core::task::TaskRegistrationError> {
+                    let task: #self_ty =
+                        genja_core::__serde_json::from_value(input).map_err(|error| {
+                            genja_core::task::TaskRegistrationError::InvalidInput {
+                                id: #registration_id.to_string(),
+                                version: #registration_version.to_string(),
+                                message: error.to_string(),
+                            }
+                        })?;
+                    Ok(genja_core::task::TaskDefinition::new(task))
+                }
+
+                genja_core::__inventory::submit! {
+                    genja_core::task::CompiledTaskRegistration::constructible(
+                        __genja_task_descriptor,
+                        __genja_task_create,
+                    )
+                }
+            };
+        }
+    } else {
+        quote! {
+            const _: () = {
+                fn __genja_task_descriptor() -> genja_core::task::TaskDescriptor {
+                    genja_core::task::TaskDescriptor::generated(
+                        format!("auto:{}", std::any::type_name::<#self_ty>()),
+                        env!("CARGO_PKG_VERSION"),
+                        genja_core::task::TaskDescriptorMetadata {
+                            name: #name.to_string(),
+                            description: None,
+                            execution_mode: #execution_mode,
+                            connection_plugin_name: #descriptor_connection_plugin_name,
+                            processor_names: vec![#(#processors.to_string()),*],
+                            retry: #descriptor_retry,
+                        },
+                    )
+                }
+
+                genja_core::__inventory::submit! {
+                    genja_core::task::CompiledTaskRegistration::descriptor_only(__genja_task_descriptor)
+                }
+            };
+        }
     };
 
     let task_impl = if has_start {

--- a/genja-core-derive/src/lib.rs
+++ b/genja-core-derive/src/lib.rs
@@ -172,7 +172,10 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 ///   `max_attempts` defaults to `1` and omitted `delay_ms` defaults to `0`.
 /// - `registration(id = "...", version = "...", description = "...")`; opts
 ///   into stable task registration and JSON construction. `id` is required and
-///   `version` defaults to `env!("CARGO_PKG_VERSION")`.
+///   `version` defaults to `env!("CARGO_PKG_VERSION")`. Use
+///   `schema = "schemars"` to include a JSON Schema for the task input in the
+///   descriptor. Schema generation requires the task type, and any nested field
+///   types, to implement `schemars::JsonSchema`.
 ///
 /// Registered tasks support three construction strategies:
 ///
@@ -187,6 +190,11 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 ///   normalization, shorthand expansion, and carefully controlled
 ///   de-obfuscation before constructing the task. Error messages should avoid
 ///   exposing raw or decoded secret values.
+///
+/// With custom factories, `schema = "schemars"` describes `Self`. If the custom
+/// factory accepts a public JSON shape that differs from the task struct, omit
+/// schema generation for now or keep the custom input contract documented
+/// separately until a dedicated input-type schema option is added.
 ///
 /// Every annotated task is discoverable through the compiled task registry with
 /// either an explicit stable ID from `registration(...)` or a generated
@@ -228,7 +236,7 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 /// use genja_core::inventory::Host;
 /// use genja_core::task::{HostTaskResult, TaskRuntimeContext, TaskSuccess};
 ///
-/// #[derive(serde::Deserialize)]
+/// #[derive(serde::Deserialize, schemars::JsonSchema)]
 /// struct ConfigureAcl {
 ///     acl_name: String,
 /// }
@@ -238,7 +246,8 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 ///     registration(
 ///         id = "acme.network.configure_acl",
 ///         version = "2.0.0",
-///         description = "Configures an ACL on a network device"
+///         description = "Configures an ACL on a network device",
+///         schema = "schemars"
 ///     )
 /// )]
 /// impl ConfigureAcl {
@@ -361,12 +370,17 @@ struct RegistrationArgs {
     version: Option<LitStr>,
     description: Option<LitStr>,
     factory: Option<RegistrationFactoryArg>,
+    schema: Option<RegistrationSchemaArg>,
 }
 
 enum RegistrationFactoryArg {
     Serde,
     Default,
     Custom(Path),
+}
+
+enum RegistrationSchemaArg {
+    Schemars,
 }
 
 #[derive(Default)]
@@ -574,10 +588,19 @@ impl Parse for RegistrationArgs {
                     }
                     args.factory = Some(parse_registration_factory_arg(input)?);
                 }
+                "schema" => {
+                    if args.schema.is_some() {
+                        return Err(syn::Error::new_spanned(
+                            key,
+                            "duplicate registration key `schema`",
+                        ));
+                    }
+                    args.schema = Some(parse_registration_schema_arg(input)?);
+                }
                 _ => {
                     return Err(syn::Error::new_spanned(
                         key,
-                        "unsupported registration key; expected `id`, `version`, `description`, or `factory`",
+                        "unsupported registration key; expected `id`, `version`, `description`, `factory`, or `schema`",
                     ));
                 }
             }
@@ -597,6 +620,17 @@ impl Parse for RegistrationArgs {
         }
 
         Ok(args)
+    }
+}
+
+fn parse_registration_schema_arg(input: ParseStream<'_>) -> syn::Result<RegistrationSchemaArg> {
+    let schema: LitStr = input.parse()?;
+    match schema.value().as_str() {
+        "schemars" => Ok(RegistrationSchemaArg::Schemars),
+        _ => Err(syn::Error::new_spanned(
+            schema,
+            "`registration(schema = ...)` supports only `\"schemars\"`",
+        )),
     }
 }
 
@@ -1166,6 +1200,17 @@ fn expand_genja_task(
             Some(description) => quote! { Some(#description.to_string()) },
             None => quote! { None },
         };
+        let registration_input_schema = match &registration.schema {
+            Some(RegistrationSchemaArg::Schemars) => quote! {
+                Some(
+                    genja_core::__serde_json::to_value(
+                        genja_core::__schemars::schema_for!(#self_ty)
+                    )
+                    .expect("schemars schema should serialize to JSON")
+                )
+            },
+            None => quote! { None },
+        };
         let registration_create = match registration
             .factory
             .as_ref()
@@ -1218,7 +1263,7 @@ fn expand_genja_task(
                             processor_names: vec![#(#processors.to_string()),*],
                             retry: #descriptor_retry,
                         },
-                        None,
+                        #registration_input_schema,
                         true,
                     )
                 }

--- a/genja-core-derive/src/lib.rs
+++ b/genja-core-derive/src/lib.rs
@@ -7,8 +7,8 @@
 //! `TaskInfo` and `Task` implementations from an inherent `impl` block, submits
 //! local discovery metadata to the compiled task registry, and infers execution
 //! mode from `fn start(...)` versus `async fn start_async(...)`. The optional
-//! `registration(...)` block gives a task a stable catalog ID and serde-backed
-//! JSON construction factory.
+//! `registration(...)` block gives a task a stable catalog ID and JSON
+//! construction factory.
 //!
 //! # Task Authoring Example
 //! ```ignore
@@ -72,9 +72,9 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
     DeriveInput, Expr, ExprArray, ExprLit, FnArg, GenericArgument, ImplItem, ItemImpl, Lit,
-    LitBool, LitInt, LitStr, PathArguments, ReturnType, Token, Type, TypePath, parenthesized,
+    LitBool, LitInt, LitStr, Path, PathArguments, ReturnType, Token, Type, TypePath, parenthesized,
     parse::{Parse, ParseStream},
-    parse_macro_input,
+    parse_macro_input, token,
 };
 
 /// Generates an implementation of the `Deref` trait for the given type.
@@ -171,11 +171,22 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 ///   disabled when the block is absent. Inside the block, omitted
 ///   `max_attempts` defaults to `1` and omitted `delay_ms` defaults to `0`.
 /// - `registration(id = "...", version = "...", description = "...")`; opts
-///   into stable task registration and JSON construction. `id` is required,
-///   `version` defaults to `env!("CARGO_PKG_VERSION")`, and `factory = "serde"`
-///   may be supplied explicitly but is the default and only supported factory
-///   for this phase. Registered task types must implement
-///   `serde::de::DeserializeOwned`.
+///   into stable task registration and JSON construction. `id` is required and
+///   `version` defaults to `env!("CARGO_PKG_VERSION")`.
+///
+/// Registered tasks support three construction strategies:
+///
+/// - Omit `factory` or use `factory = "serde"` to deserialize JSON input into
+///   the task type. The task type must implement `serde::de::DeserializeOwned`.
+/// - Use `factory = "default"` for no-input tasks. The task type must implement
+///   `Default`; input must be `null` or `{}`.
+/// - Use `factory = custom(path::to::function)` for advanced input
+///   preparation. The function receives `serde_json::Value` and must return
+///   `Result<Self, genja_core::task::TaskRegistrationError>`, where `Self` is
+///   the task type. Custom factories are intended for validation,
+///   normalization, shorthand expansion, and carefully controlled
+///   de-obfuscation before constructing the task. Error messages should avoid
+///   exposing raw or decoded secret values.
 ///
 /// Every annotated task is discoverable through the compiled task registry with
 /// either an explicit stable ID from `registration(...)` or a generated
@@ -240,6 +251,67 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
+///
+/// Custom factories can keep the public JSON contract separate from the
+/// internal Rust struct. This is useful when task input needs preparation before
+/// execution, such as expanding shorthand or decoding obfuscated values.
+///
+/// ```ignore
+/// use genja_core::genja_task;
+/// use genja_core::inventory::Host;
+/// use genja_core::task::{
+///     HostTaskResult, TaskRegistrationError, TaskRuntimeContext, TaskSuccess,
+/// };
+///
+/// struct ConfigureAcl {
+///     acl_name: String,
+///     secret_token: String,
+/// }
+///
+/// fn create_configure_acl(
+///     input: serde_json::Value,
+/// ) -> Result<ConfigureAcl, TaskRegistrationError> {
+///     let acl_name = input
+///         .get("acl")
+///         .and_then(serde_json::Value::as_str)
+///         .ok_or_else(|| TaskRegistrationError::InvalidInput {
+///             id: "acme.network.configure_acl".to_string(),
+///             version: "2.0.0".to_string(),
+///             message: "`acl` is required".to_string(),
+///         })?;
+///     let token = input
+///         .get("token_obfuscated")
+///         .and_then(serde_json::Value::as_str)
+///         .ok_or_else(|| TaskRegistrationError::InvalidInput {
+///             id: "acme.network.configure_acl".to_string(),
+///             version: "2.0.0".to_string(),
+///             message: "`token_obfuscated` is required".to_string(),
+///         })?;
+///
+///     Ok(ConfigureAcl {
+///         acl_name: acl_name.to_string(),
+///         secret_token: token.chars().rev().collect(),
+///     })
+/// }
+///
+/// #[genja_task(
+///     name = "configure_acl",
+///     registration(
+///         id = "acme.network.configure_acl",
+///         version = "2.0.0",
+///         factory = custom(create_configure_acl)
+///     )
+/// )]
+/// impl ConfigureAcl {
+///     async fn start_async(
+///         &self,
+///         _host: &Host,
+///         _context: &TaskRuntimeContext,
+///     ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+///         Ok(HostTaskResult::passed(TaskSuccess::new()))
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn genja_task(args: TokenStream, input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as GenjaTaskArgs);
@@ -288,7 +360,13 @@ struct RegistrationArgs {
     id: Option<LitStr>,
     version: Option<LitStr>,
     description: Option<LitStr>,
-    factory: Option<LitStr>,
+    factory: Option<RegistrationFactoryArg>,
+}
+
+enum RegistrationFactoryArg {
+    Serde,
+    Default,
+    Custom(Path),
 }
 
 #[derive(Default)]
@@ -494,14 +572,7 @@ impl Parse for RegistrationArgs {
                             "duplicate registration key `factory`",
                         ));
                     }
-                    let factory: LitStr = input.parse()?;
-                    if factory.value() != "serde" {
-                        return Err(syn::Error::new_spanned(
-                            factory,
-                            "`registration(factory = ...)` currently supports only `\"serde\"`; omit `factory` to use serde",
-                        ));
-                    }
-                    args.factory = Some(factory);
+                    args.factory = Some(parse_registration_factory_arg(input)?);
                 }
                 _ => {
                     return Err(syn::Error::new_spanned(
@@ -527,6 +598,50 @@ impl Parse for RegistrationArgs {
 
         Ok(args)
     }
+}
+
+fn parse_registration_factory_arg(input: ParseStream<'_>) -> syn::Result<RegistrationFactoryArg> {
+    if input.peek(LitStr) {
+        let factory: LitStr = input.parse()?;
+        return match factory.value().as_str() {
+            "serde" => Ok(RegistrationFactoryArg::Serde),
+            "default" => Ok(RegistrationFactoryArg::Default),
+            "custom" => Err(syn::Error::new_spanned(
+                factory,
+                "use `factory = custom(path)` to configure a custom registration factory",
+            )),
+            _ => Err(syn::Error::new_spanned(
+                factory,
+                "`registration(factory = ...)` supports `\"serde\"`, `\"default\"`, or `custom(path)`",
+            )),
+        };
+    }
+
+    let factory: syn::Ident = input.parse()?;
+    if factory != "custom" {
+        return Err(syn::Error::new_spanned(
+            factory,
+            "`registration(factory = ...)` supports `\"serde\"`, `\"default\"`, or `custom(path)`",
+        ));
+    }
+
+    if !input.peek(token::Paren) {
+        return Err(syn::Error::new_spanned(
+            factory,
+            "`factory = custom(...)` requires a factory function path",
+        ));
+    }
+
+    let content;
+    parenthesized!(content in input);
+    let factory_path: Path = content.parse()?;
+    if !content.is_empty() {
+        return Err(syn::Error::new_spanned(
+            factory_path,
+            "`factory = custom(...)` accepts exactly one factory function path",
+        ));
+    }
+    Ok(RegistrationFactoryArg::Custom(factory_path))
 }
 
 fn validate_registration_id_literal(id: &LitStr) -> syn::Result<()> {
@@ -1051,6 +1166,43 @@ fn expand_genja_task(
             Some(description) => quote! { Some(#description.to_string()) },
             None => quote! { None },
         };
+        let registration_create = match registration
+            .factory
+            .as_ref()
+            .unwrap_or(&RegistrationFactoryArg::Serde)
+        {
+            RegistrationFactoryArg::Serde => quote! {
+                let task: #self_ty =
+                    genja_core::__serde_json::from_value(input).map_err(|error| {
+                        genja_core::task::TaskRegistrationError::InvalidInput {
+                            id: #registration_id.to_string(),
+                            version: #registration_version.to_string(),
+                            message: error.to_string(),
+                        }
+                    })?;
+                Ok(genja_core::task::TaskDefinition::new(task))
+            },
+            RegistrationFactoryArg::Default => quote! {
+                if !input.is_null()
+                    && !input
+                        .as_object()
+                        .is_some_and(|object| object.is_empty())
+                {
+                    return Err(genja_core::task::TaskRegistrationError::InvalidInput {
+                        id: #registration_id.to_string(),
+                        version: #registration_version.to_string(),
+                        message: "default factory expects empty input (`null` or `{}`)".to_string(),
+                    });
+                }
+
+                let task: #self_ty = <#self_ty as std::default::Default>::default();
+                Ok(genja_core::task::TaskDefinition::new(task))
+            },
+            RegistrationFactoryArg::Custom(factory_path) => quote! {
+                let task: #self_ty = #factory_path(input)?;
+                Ok(genja_core::task::TaskDefinition::new(task))
+            },
+        };
 
         quote! {
             const _: () = {
@@ -1074,15 +1226,7 @@ fn expand_genja_task(
                 fn __genja_task_create(
                     input: genja_core::__serde_json::Value,
                 ) -> Result<genja_core::task::TaskDefinition, genja_core::task::TaskRegistrationError> {
-                    let task: #self_ty =
-                        genja_core::__serde_json::from_value(input).map_err(|error| {
-                            genja_core::task::TaskRegistrationError::InvalidInput {
-                                id: #registration_id.to_string(),
-                                version: #registration_version.to_string(),
-                                message: error.to_string(),
-                            }
-                        })?;
-                    Ok(genja_core::task::TaskDefinition::new(task))
+                    #registration_create
                 }
 
                 genja_core::__inventory::submit! {

--- a/genja-core/Cargo.toml
+++ b/genja-core/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools", "asynchronous", "network-programming"]
 [dependencies]
 async-recursion = "1.1.1"
 async-trait = "0.1.89"
+inventory_crate = { package = "inventory", version = "0.3.24" }
 log = "0.4.27"
 natord = "1.0.9"
 genja-core-derive = { version = "0.3.0", path = "../genja-core-derive" }

--- a/genja-core/Cargo.toml
+++ b/genja-core/Cargo.toml
@@ -18,6 +18,7 @@ log = "0.4.27"
 natord = "1.0.9"
 genja-core-derive = { version = "0.3.0", path = "../genja-core-derive" }
 schemars = "1.0.4"
+semver = "1.0.23"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.142"
 serde_yaml = "0.9.34"

--- a/genja-core/src/lib.rs
+++ b/genja-core/src/lib.rs
@@ -69,6 +69,8 @@ pub use ::async_trait::async_trait;
 #[doc(hidden)]
 pub use ::inventory_crate as __inventory;
 #[doc(hidden)]
+pub use ::schemars as __schemars;
+#[doc(hidden)]
 pub use ::serde as __serde;
 #[doc(hidden)]
 pub use ::serde_json as __serde_json;

--- a/genja-core/src/lib.rs
+++ b/genja-core/src/lib.rs
@@ -68,6 +68,10 @@ pub mod types;
 pub use ::async_trait::async_trait;
 #[doc(hidden)]
 pub use ::inventory_crate as __inventory;
+#[doc(hidden)]
+pub use ::serde as __serde;
+#[doc(hidden)]
+pub use ::serde_json as __serde_json;
 pub use errors::{
     ConfigLoadError, GenjaError, InventoryFileKind, InventoryLoadError, SshConfigError,
 };

--- a/genja-core/src/lib.rs
+++ b/genja-core/src/lib.rs
@@ -66,6 +66,8 @@ pub mod task;
 pub mod types;
 
 pub use ::async_trait::async_trait;
+#[doc(hidden)]
+pub use ::inventory_crate as __inventory;
 pub use errors::{
     ConfigLoadError, GenjaError, InventoryFileKind, InventoryLoadError, SshConfigError,
 };

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -646,7 +646,10 @@ use tokio::task;
 use tokio::time::{Duration, sleep};
 
 pub mod registration;
-pub use registration::{TaskDescriptor, TaskDescriptorMetadata, TaskIdSource};
+pub use registration::{
+    TaskDescriptor, TaskDescriptorMetadata, TaskIdSource, TaskRegistrationError,
+    TaskRegistrationKey, validate_explicit_task_id, validate_task_version,
+};
 
 /// Optional retry metadata for a task or runner.
 ///

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -645,6 +645,9 @@ use tokio::sync::Mutex;
 use tokio::task;
 use tokio::time::{Duration, sleep};
 
+pub mod registration;
+pub use registration::{TaskDescriptor, TaskIdSource};
+
 /// Optional retry metadata for a task or runner.
 ///
 /// Each field is optional so task-level metadata can override runner defaults
@@ -3631,7 +3634,8 @@ pub trait TaskInfo {
 }
 
 /// Sub-task provider interface.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TaskExecutionMode {
     Blocking,
     Async,

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -656,7 +656,7 @@ pub use registration::{
     validate_task_version,
 };
 pub use spec::{
-    TaskSpec, TaskSpecConstructionError, TaskSpecError, TaskSpecFormat,
+    TaskSpec, TaskSpecConstructionError, TaskSpecError, TaskSpecFormat, TaskSpecOverrides,
     create_compiled_task_from_spec, create_compiled_task_from_spec_str,
     create_compiled_task_from_spec_str_with_format,
 };
@@ -4270,6 +4270,8 @@ pub struct TaskDefinition {
     inner: Arc<dyn Task>,
     processor_resolver: Option<Arc<dyn TaskProcessorResolver>>,
     processor_names: Arc<Vec<String>>,
+    retry_config_override: Option<RetryConfig>,
+    session_verification_config_override: Option<SessionVerificationConfig>,
 }
 
 impl fmt::Debug for TaskDefinition {
@@ -4280,6 +4282,11 @@ impl fmt::Debug for TaskDefinition {
             .field("connection_plugin_name", &self.connection_plugin_name())
             .field("processor_names", &self.processor_names())
             .field("has_processor_resolver", &self.processor_resolver.is_some())
+            .field("retry_config_override", &self.retry_config_override)
+            .field(
+                "session_verification_config_override",
+                &self.session_verification_config_override,
+            )
             .finish()
     }
 }
@@ -4291,6 +4298,8 @@ impl TaskDefinition {
             inner: Arc::new(task),
             processor_resolver: None,
             processor_names: Arc::new(Vec::new()),
+            retry_config_override: None,
+            session_verification_config_override: None,
         }
     }
 
@@ -4325,6 +4334,27 @@ impl TaskDefinition {
         processor_resolver: Arc<dyn TaskProcessorResolver>,
     ) -> Self {
         self.processor_resolver = Some(processor_resolver);
+        self
+    }
+
+    /// Override the root task's retry policy for this task definition.
+    ///
+    /// This is a per-definition runtime policy override. It does not mutate the
+    /// authored task metadata and does not apply to sub-tasks.
+    pub fn with_retry_config_override(mut self, retry_config: RetryConfig) -> Self {
+        self.retry_config_override = Some(retry_config);
+        self
+    }
+
+    /// Override the root task's post-change session verification policy.
+    ///
+    /// This is a per-definition runtime policy override. It does not mutate the
+    /// authored task metadata and does not apply to sub-tasks.
+    pub fn with_session_verification_config_override(
+        mut self,
+        session_verification_config: SessionVerificationConfig,
+    ) -> Self {
+        self.session_verification_config_override = Some(session_verification_config);
         self
     }
 
@@ -5136,11 +5166,15 @@ impl TaskInfo for TaskDefinition {
     }
 
     fn retry_config(&self) -> Option<&RetryConfig> {
-        self.inner.retry_config()
+        self.retry_config_override
+            .as_ref()
+            .or_else(|| self.inner.retry_config())
     }
 
     fn session_verification_config(&self) -> Option<&SessionVerificationConfig> {
-        self.inner.session_verification_config()
+        self.session_verification_config_override
+            .as_ref()
+            .or_else(|| self.inner.session_verification_config())
     }
 
     fn supports_dry_run(&self) -> bool {
@@ -8123,6 +8157,50 @@ mod tests {
         let task = TaskDefinition::new(DryRunInfoTask);
 
         assert!(task.supports_dry_run());
+    }
+
+    #[test]
+    fn task_definition_retry_override_wins_over_authored_metadata() {
+        let task = TaskDefinition::new(RetryConfiguredFlakyTask {
+            inner: FlakyTask {
+                name: "retry-override",
+                attempts: Arc::new(AtomicUsize::new(0)),
+                succeed_on_attempt: 1,
+            },
+            retry_config: RetryConfig::builder()
+                .allow(true)
+                .max_attempts(3)
+                .delay_ms(100)
+                .build(),
+        })
+        .with_retry_config_override(
+            RetryConfig::builder()
+                .allow(false)
+                .max_attempts(2)
+                .delay_ms(250)
+                .build(),
+        );
+
+        let retry_config = task
+            .retry_config()
+            .expect("retry override should be present");
+        assert_eq!(retry_config.allow(), Some(false));
+        assert_eq!(retry_config.max_attempts(), Some(2));
+        assert_eq!(retry_config.delay_ms(), Some(250));
+    }
+
+    #[test]
+    fn task_definition_session_verification_override_wins_over_authored_metadata() {
+        let task = TaskDefinition::new(SessionVerificationInfoTask {
+            config: SessionVerificationConfig::new(3, 5_000),
+        })
+        .with_session_verification_config_override(SessionVerificationConfig::new(2, 1_000));
+
+        let config = task
+            .session_verification_config()
+            .expect("session verification override should be present");
+        assert_eq!(config.max_attempts(), 2);
+        assert_eq!(config.delay_ms(), 1_000);
     }
 
     #[test]

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -650,7 +650,8 @@ pub use registration::{
     CompiledTaskRegistration, InMemoryTaskRegistry, RegisteredTaskFactory, TaskCatalog,
     TaskDescriptor, TaskDescriptorMetadata, TaskFactoryRegistry, TaskIdSource,
     TaskRegistrationError, TaskRegistrationKey, compiled_task_registry,
-    get_compiled_task_descriptor, list_compiled_tasks, validate_explicit_task_id,
+    create_compiled_task_by_identity, get_compiled_task_descriptor,
+    get_compiled_task_descriptor_by_identity, list_compiled_tasks, validate_explicit_task_id,
     validate_task_version,
 };
 

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -646,6 +646,7 @@ use tokio::task;
 use tokio::time::{Duration, sleep};
 
 pub mod registration;
+pub mod spec;
 pub use registration::{
     CompiledTaskRegistration, InMemoryTaskRegistry, RegisteredTaskFactory, TaskCatalog,
     TaskDescriptor, TaskDescriptorMetadata, TaskFactoryRegistry, TaskIdSource,
@@ -654,6 +655,7 @@ pub use registration::{
     get_compiled_task_descriptor_by_identity, list_compiled_tasks, validate_explicit_task_id,
     validate_task_version,
 };
+pub use spec::{TaskSpec, TaskSpecError};
 
 /// Optional retry metadata for a task or runner.
 ///

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -647,7 +647,8 @@ use tokio::time::{Duration, sleep};
 
 pub mod registration;
 pub use registration::{
-    TaskDescriptor, TaskDescriptorMetadata, TaskIdSource, TaskRegistrationError,
+    InMemoryTaskRegistry, RegisteredTaskFactory, TaskCatalog, TaskDescriptor,
+    TaskDescriptorMetadata, TaskFactoryRegistry, TaskIdSource, TaskRegistrationError,
     TaskRegistrationKey, validate_explicit_task_id, validate_task_version,
 };
 

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -655,7 +655,11 @@ pub use registration::{
     get_compiled_task_descriptor_by_identity, list_compiled_tasks, validate_explicit_task_id,
     validate_task_version,
 };
-pub use spec::{TaskSpec, TaskSpecError, TaskSpecFormat};
+pub use spec::{
+    TaskSpec, TaskSpecConstructionError, TaskSpecError, TaskSpecFormat,
+    create_compiled_task_from_spec, create_compiled_task_from_spec_str,
+    create_compiled_task_from_spec_str_with_format,
+};
 
 /// Optional retry metadata for a task or runner.
 ///
@@ -4266,6 +4270,18 @@ pub struct TaskDefinition {
     inner: Arc<dyn Task>,
     processor_resolver: Option<Arc<dyn TaskProcessorResolver>>,
     processor_names: Arc<Vec<String>>,
+}
+
+impl fmt::Debug for TaskDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TaskDefinition")
+            .field("name", &self.name())
+            .field("execution_mode", &self.inner.execution_mode())
+            .field("connection_plugin_name", &self.connection_plugin_name())
+            .field("processor_names", &self.processor_names())
+            .field("has_processor_resolver", &self.processor_resolver.is_some())
+            .finish()
+    }
 }
 
 impl TaskDefinition {
@@ -8107,6 +8123,22 @@ mod tests {
         let task = TaskDefinition::new(DryRunInfoTask);
 
         assert!(task.supports_dry_run());
+    }
+
+    #[test]
+    fn task_definition_debug_includes_metadata_only() {
+        let task = TaskDefinition::new(ProcessorTask {
+            name: "processor-root",
+            processors: vec!["audit".to_string()],
+        });
+
+        let debug = format!("{task:?}");
+
+        assert!(debug.contains("TaskDefinition"));
+        assert!(debug.contains("processor-root"));
+        assert!(debug.contains("Async"));
+        assert!(debug.contains("audit"));
+        assert!(debug.contains("has_processor_resolver: false"));
     }
 
     #[test]

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -647,9 +647,11 @@ use tokio::time::{Duration, sleep};
 
 pub mod registration;
 pub use registration::{
-    InMemoryTaskRegistry, RegisteredTaskFactory, TaskCatalog, TaskDescriptor,
-    TaskDescriptorMetadata, TaskFactoryRegistry, TaskIdSource, TaskRegistrationError,
-    TaskRegistrationKey, validate_explicit_task_id, validate_task_version,
+    CompiledTaskRegistration, InMemoryTaskRegistry, RegisteredTaskFactory, TaskCatalog,
+    TaskDescriptor, TaskDescriptorMetadata, TaskFactoryRegistry, TaskIdSource,
+    TaskRegistrationError, TaskRegistrationKey, compiled_task_registry,
+    get_compiled_task_descriptor, list_compiled_tasks, validate_explicit_task_id,
+    validate_task_version,
 };
 
 /// Optional retry metadata for a task or runner.

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -646,7 +646,7 @@ use tokio::task;
 use tokio::time::{Duration, sleep};
 
 pub mod registration;
-pub use registration::{TaskDescriptor, TaskIdSource};
+pub use registration::{TaskDescriptor, TaskDescriptorMetadata, TaskIdSource};
 
 /// Optional retry metadata for a task or runner.
 ///

--- a/genja-core/src/task.rs
+++ b/genja-core/src/task.rs
@@ -655,7 +655,7 @@ pub use registration::{
     get_compiled_task_descriptor_by_identity, list_compiled_tasks, validate_explicit_task_id,
     validate_task_version,
 };
-pub use spec::{TaskSpec, TaskSpecError};
+pub use spec::{TaskSpec, TaskSpecError, TaskSpecFormat};
 
 /// Optional retry metadata for a task or runner.
 ///

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -5,11 +5,13 @@
 //! Python registration integrations. The descriptor is metadata only; local
 //! construction from JSON input is handled by later factory registry APIs.
 
-use super::{RetryConfig, TaskExecutionMode};
+use super::{RetryConfig, TaskDefinition, TaskExecutionMode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
+use std::sync::Arc;
 
 /// Errors returned by task registration, discovery, and construction APIs.
 ///
@@ -301,6 +303,241 @@ pub fn validate_task_version(version: &str) -> Result<(), TaskRegistrationError>
     Ok(())
 }
 
+/// Read-only catalog of task descriptors.
+///
+/// Catalog implementations provide metadata listing and lookup. They do not
+/// need access to local Rust factories, which lets future SQLite, provider
+/// manifest, remote catalog, and MCP metadata sources implement this trait
+/// without supporting in-process task construction.
+pub trait TaskCatalog {
+    /// Return all known task descriptors in deterministic order.
+    fn list(&self) -> Result<Vec<TaskDescriptor>, TaskRegistrationError>;
+
+    /// Look up a descriptor by ID and optional version.
+    ///
+    /// When `version` is `None`, the lookup succeeds only if exactly one
+    /// version exists for `id`; multiple matches return
+    /// [`TaskRegistrationError::AmbiguousVersion`].
+    fn get(&self, id: &str, version: Option<&str>)
+    -> Result<TaskDescriptor, TaskRegistrationError>;
+}
+
+/// Local factory registry for constructing tasks from JSON-compatible input.
+///
+/// This trait is intentionally separate from [`TaskCatalog`] because persistent
+/// catalogs can store descriptors but cannot store Rust function pointers or
+/// closures.
+pub trait TaskFactoryRegistry {
+    /// Construct a local task definition by ID, optional version, and input.
+    fn create(
+        &self,
+        id: &str,
+        version: Option<&str>,
+        input: Value,
+    ) -> Result<TaskDefinition, TaskRegistrationError>;
+}
+
+/// Type-erased factory for one registered task.
+///
+/// Macro-generated registrations will implement this trait for each
+/// constructible task. The registry only calls this common interface; the
+/// factory implementation owns the task-specific construction strategy.
+pub trait RegisteredTaskFactory: Send + Sync {
+    /// Return the descriptor for the task this factory constructs.
+    fn descriptor(&self) -> &TaskDescriptor;
+
+    /// Construct a task definition from JSON-compatible input.
+    fn create(&self, input: Value) -> Result<TaskDefinition, TaskRegistrationError>;
+}
+
+#[derive(Clone)]
+enum InMemoryTaskEntry {
+    Descriptor(Box<TaskDescriptor>),
+    Factory(Arc<dyn RegisteredTaskFactory>),
+}
+
+impl InMemoryTaskEntry {
+    fn descriptor(&self) -> &TaskDescriptor {
+        match self {
+            Self::Descriptor(descriptor) => descriptor,
+            Self::Factory(factory) => factory.descriptor(),
+        }
+    }
+}
+
+/// In-memory task catalog and local factory registry.
+///
+/// `InMemoryTaskRegistry` is useful for tests, manually assembled local
+/// registries, and as the behavior model for the future compiled registry. It
+/// stores descriptor-only entries as well as factory-backed constructible
+/// entries, rejects duplicate `id + version` pairs, and performs deterministic
+/// version lookup.
+#[derive(Clone, Default)]
+pub struct InMemoryTaskRegistry {
+    entries: BTreeMap<(String, String), InMemoryTaskEntry>,
+}
+
+impl InMemoryTaskRegistry {
+    /// Create an empty in-memory task registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a registry from descriptor-only entries.
+    pub fn from_descriptors<I>(descriptors: I) -> Result<Self, TaskRegistrationError>
+    where
+        I: IntoIterator<Item = TaskDescriptor>,
+    {
+        let mut registry = Self::new();
+        for descriptor in descriptors {
+            registry.register_descriptor(descriptor)?;
+        }
+        Ok(registry)
+    }
+
+    /// Add a descriptor-only task entry.
+    ///
+    /// Descriptor-only entries can be listed and looked up but cannot be
+    /// constructed through [`TaskFactoryRegistry::create`].
+    pub fn register_descriptor(
+        &mut self,
+        descriptor: TaskDescriptor,
+    ) -> Result<(), TaskRegistrationError> {
+        validate_descriptor(&descriptor)?;
+        self.insert_entry(InMemoryTaskEntry::Descriptor(Box::new(descriptor)))
+    }
+
+    /// Add a constructible factory-backed task entry.
+    pub fn register_factory<F>(&mut self, factory: F) -> Result<(), TaskRegistrationError>
+    where
+        F: RegisteredTaskFactory + 'static,
+    {
+        self.register_factory_arc(Arc::new(factory))
+    }
+
+    /// Add a shared constructible factory-backed task entry.
+    pub fn register_factory_arc(
+        &mut self,
+        factory: Arc<dyn RegisteredTaskFactory>,
+    ) -> Result<(), TaskRegistrationError> {
+        validate_descriptor(factory.descriptor())?;
+        self.insert_entry(InMemoryTaskEntry::Factory(factory))
+    }
+
+    fn insert_entry(&mut self, entry: InMemoryTaskEntry) -> Result<(), TaskRegistrationError> {
+        let descriptor = entry.descriptor();
+        let key = (descriptor.id.clone(), descriptor.version.clone());
+
+        if self.entries.contains_key(&key) {
+            return Err(TaskRegistrationError::DuplicateRegistration {
+                id: key.0,
+                version: key.1,
+            });
+        }
+
+        self.entries.insert(key, entry);
+        Ok(())
+    }
+
+    fn resolve_entry(
+        &self,
+        id: &str,
+        version: Option<&str>,
+    ) -> Result<&InMemoryTaskEntry, TaskRegistrationError> {
+        if let Some(version) = version {
+            return self
+                .entries
+                .get(&(id.to_string(), version.to_string()))
+                .ok_or_else(|| TaskRegistrationError::NotFound {
+                    id: id.to_string(),
+                    version: Some(version.to_string()),
+                });
+        }
+
+        let mut matches = self
+            .entries
+            .iter()
+            .filter(|((entry_id, _), _)| entry_id == id)
+            .map(|((_, entry_version), entry)| (entry_version.clone(), entry));
+
+        let Some((first_version, first_entry)) = matches.next() else {
+            return Err(TaskRegistrationError::NotFound {
+                id: id.to_string(),
+                version: None,
+            });
+        };
+
+        let mut versions = vec![first_version];
+        for (entry_version, _) in matches {
+            versions.push(entry_version);
+        }
+
+        if versions.len() > 1 {
+            return Err(TaskRegistrationError::AmbiguousVersion {
+                id: id.to_string(),
+                versions,
+            });
+        }
+
+        Ok(first_entry)
+    }
+}
+
+impl TaskCatalog for InMemoryTaskRegistry {
+    fn list(&self) -> Result<Vec<TaskDescriptor>, TaskRegistrationError> {
+        Ok(self
+            .entries
+            .values()
+            .map(|entry| entry.descriptor().clone())
+            .collect())
+    }
+
+    fn get(
+        &self,
+        id: &str,
+        version: Option<&str>,
+    ) -> Result<TaskDescriptor, TaskRegistrationError> {
+        Ok(self.resolve_entry(id, version)?.descriptor().clone())
+    }
+}
+
+impl TaskFactoryRegistry for InMemoryTaskRegistry {
+    fn create(
+        &self,
+        id: &str,
+        version: Option<&str>,
+        input: Value,
+    ) -> Result<TaskDefinition, TaskRegistrationError> {
+        let entry = self.resolve_entry(id, version)?;
+        let descriptor = entry.descriptor();
+
+        if !descriptor.constructible {
+            return Err(TaskRegistrationError::NotConstructible {
+                id: descriptor.id.clone(),
+                version: descriptor.version.clone(),
+            });
+        }
+
+        match entry {
+            InMemoryTaskEntry::Descriptor(descriptor) => {
+                Err(TaskRegistrationError::NotConstructible {
+                    id: descriptor.id.clone(),
+                    version: descriptor.version.clone(),
+                })
+            }
+            InMemoryTaskEntry::Factory(factory) => factory.create(input),
+        }
+    }
+}
+
+fn validate_descriptor(descriptor: &TaskDescriptor) -> Result<(), TaskRegistrationError> {
+    if descriptor.id_source == TaskIdSource::Explicit {
+        validate_explicit_task_id(&descriptor.id)?;
+    }
+    validate_task_version(&descriptor.version)?;
+    Ok(())
+}
+
 /// Indicates how a task descriptor's `id` was chosen.
 ///
 /// Generated IDs are useful for local discovery but are derived from Rust
@@ -439,6 +676,12 @@ pub struct TaskDescriptorMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::async_trait;
+    use crate::inventory::Host;
+    use crate::task::{
+        BlockingTaskRuntimeContext, HostTaskResult, Task, TaskError, TaskInfo, TaskRuntimeContext,
+        TaskSuccess,
+    };
     use serde_json::json;
 
     fn descriptor_metadata() -> TaskDescriptorMetadata {
@@ -449,6 +692,79 @@ mod tests {
             connection_plugin_name: Some("ssh".to_string()),
             processor_names: vec!["audit".to_string()],
             retry: Some(RetryConfig::builder().allow(true).max_attempts(3).build()),
+        }
+    }
+
+    fn explicit_descriptor(id: &str, version: &str, constructible: bool) -> TaskDescriptor {
+        TaskDescriptor::explicit(id, version, descriptor_metadata(), None, constructible)
+    }
+
+    fn generated_descriptor(id: &str, version: &str) -> TaskDescriptor {
+        TaskDescriptor::generated(id, version, descriptor_metadata())
+    }
+
+    struct RegistryTestTask {
+        name: &'static str,
+    }
+
+    impl TaskInfo for RegistryTestTask {
+        fn name(&self) -> &str {
+            self.name
+        }
+    }
+
+    #[async_trait]
+    impl Task for RegistryTestTask {
+        fn start(
+            &self,
+            _host: &Host,
+            _context: &BlockingTaskRuntimeContext,
+        ) -> Result<HostTaskResult, TaskError> {
+            Ok(HostTaskResult::passed(TaskSuccess::new()))
+        }
+
+        async fn start_async(
+            &self,
+            _host: &Host,
+            _context: &TaskRuntimeContext,
+        ) -> Result<HostTaskResult, TaskError> {
+            Ok(HostTaskResult::passed(TaskSuccess::new()))
+        }
+
+        fn execution_mode(&self) -> TaskExecutionMode {
+            TaskExecutionMode::Async
+        }
+    }
+
+    struct RegistryTestFactory {
+        descriptor: TaskDescriptor,
+    }
+
+    impl RegistryTestFactory {
+        fn new(id: &str, version: &str) -> Self {
+            Self {
+                descriptor: explicit_descriptor(id, version, true),
+            }
+        }
+    }
+
+    impl RegisteredTaskFactory for RegistryTestFactory {
+        fn descriptor(&self) -> &TaskDescriptor {
+            &self.descriptor
+        }
+
+        fn create(&self, input: Value) -> Result<TaskDefinition, TaskRegistrationError> {
+            if input != json!({ "ok": true }) {
+                return Err(TaskRegistrationError::InvalidInput {
+                    id: self.descriptor.id.clone(),
+                    version: self.descriptor.version.clone(),
+                    message: "expected ok flag".to_string(),
+                });
+            }
+
+            Ok(TaskDefinition::new(RegistryTestTask {
+                name: "registry_test_task",
+            }))
         }
     }
 
@@ -802,6 +1118,217 @@ mod tests {
             }
             .to_string(),
             "registered task `acme.network.configure_acl` has multiple versions: 1.0.0, 2.0.0"
+        );
+    }
+
+    #[test]
+    fn in_memory_registry_lists_descriptors_in_deterministic_order() {
+        let registry = InMemoryTaskRegistry::from_descriptors([
+            explicit_descriptor("zeta.task", "1.0.0", false),
+            explicit_descriptor("acme.task", "2.0.0", false),
+            explicit_descriptor("acme.task", "1.0.0", false),
+        ])
+        .expect("descriptors should register");
+
+        let listed = registry.list().expect("list should succeed");
+        let identities = listed
+            .iter()
+            .map(|descriptor| format!("{}@{}", descriptor.id, descriptor.version))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            identities,
+            vec!["acme.task@1.0.0", "acme.task@2.0.0", "zeta.task@1.0.0"]
+        );
+    }
+
+    #[test]
+    fn in_memory_registry_gets_exact_version() {
+        let registry = InMemoryTaskRegistry::from_descriptors([
+            explicit_descriptor("acme.task", "1.0.0", false),
+            explicit_descriptor("acme.task", "2.0.0", false),
+        ])
+        .expect("descriptors should register");
+
+        let descriptor = registry
+            .get("acme.task", Some("2.0.0"))
+            .expect("descriptor should exist");
+
+        assert_eq!(descriptor.id, "acme.task");
+        assert_eq!(descriptor.version, "2.0.0");
+    }
+
+    #[test]
+    fn in_memory_registry_get_without_version_succeeds_for_single_match() {
+        let registry = InMemoryTaskRegistry::from_descriptors([
+            explicit_descriptor("acme.task", "1.0.0", false),
+            explicit_descriptor("zeta.task", "1.0.0", false),
+        ])
+        .expect("descriptors should register");
+
+        let descriptor = registry
+            .get("acme.task", None)
+            .expect("single version should resolve");
+
+        assert_eq!(descriptor.id, "acme.task");
+        assert_eq!(descriptor.version, "1.0.0");
+    }
+
+    #[test]
+    fn in_memory_registry_get_without_version_rejects_ambiguity() {
+        let registry = InMemoryTaskRegistry::from_descriptors([
+            explicit_descriptor("acme.task", "1.0.0", false),
+            explicit_descriptor("acme.task", "2.0.0", false),
+        ])
+        .expect("descriptors should register");
+
+        let error = registry
+            .get("acme.task", None)
+            .expect_err("multiple versions should be ambiguous");
+
+        assert_eq!(
+            error,
+            TaskRegistrationError::AmbiguousVersion {
+                id: "acme.task".to_string(),
+                versions: vec!["1.0.0".to_string(), "2.0.0".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn in_memory_registry_get_returns_not_found() {
+        let registry = InMemoryTaskRegistry::from_descriptors([explicit_descriptor(
+            "acme.task",
+            "1.0.0",
+            false,
+        )])
+        .expect("descriptors should register");
+
+        assert_eq!(
+            registry
+                .get("missing.task", None)
+                .expect_err("missing id should fail"),
+            TaskRegistrationError::NotFound {
+                id: "missing.task".to_string(),
+                version: None,
+            }
+        );
+        assert_eq!(
+            registry
+                .get("acme.task", Some("2.0.0"))
+                .expect_err("missing version should fail"),
+            TaskRegistrationError::NotFound {
+                id: "acme.task".to_string(),
+                version: Some("2.0.0".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn in_memory_registry_rejects_duplicate_id_and_version() {
+        let error = InMemoryTaskRegistry::from_descriptors([
+            explicit_descriptor("acme.task", "1.0.0", false),
+            explicit_descriptor("acme.task", "1.0.0", false),
+        ])
+        .err()
+        .expect("duplicate descriptors should fail");
+
+        assert_eq!(
+            error,
+            TaskRegistrationError::DuplicateRegistration {
+                id: "acme.task".to_string(),
+                version: "1.0.0".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn in_memory_registry_validates_explicit_descriptors_only_as_explicit_ids() {
+        let generated =
+            generated_descriptor("auto:acme_network_tasks::network::ConfigureAcl", "1.0.0");
+        InMemoryTaskRegistry::from_descriptors([generated])
+            .expect("generated ids should not use explicit id validation");
+
+        let explicit = explicit_descriptor(
+            "auto:acme_network_tasks::network::ConfigureAcl",
+            "1.0.0",
+            false,
+        );
+        assert!(matches!(
+            InMemoryTaskRegistry::from_descriptors([explicit]),
+            Err(TaskRegistrationError::InvalidId { .. })
+        ));
+    }
+
+    #[test]
+    fn in_memory_registry_validates_descriptor_versions() {
+        let descriptor =
+            generated_descriptor("auto:acme_network_tasks::network::ConfigureAcl", "latest");
+
+        assert!(matches!(
+            InMemoryTaskRegistry::from_descriptors([descriptor]),
+            Err(TaskRegistrationError::InvalidVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn in_memory_registry_creates_factory_backed_task() {
+        let mut registry = InMemoryTaskRegistry::new();
+        registry
+            .register_factory(RegistryTestFactory::new("acme.task", "1.0.0"))
+            .expect("factory should register");
+
+        let task = registry
+            .create("acme.task", None, json!({ "ok": true }))
+            .expect("factory should create task");
+
+        assert_eq!(task.as_task().name(), "registry_test_task");
+    }
+
+    #[test]
+    fn in_memory_registry_propagates_factory_errors_without_raw_input() {
+        let mut registry = InMemoryTaskRegistry::new();
+        registry
+            .register_factory(RegistryTestFactory::new("acme.task", "1.0.0"))
+            .expect("factory should register");
+
+        let error = registry
+            .create("acme.task", Some("1.0.0"), json!({ "secret": "value" }))
+            .err()
+            .expect("factory should reject input");
+
+        assert_eq!(
+            error,
+            TaskRegistrationError::InvalidInput {
+                id: "acme.task".to_string(),
+                version: "1.0.0".to_string(),
+                message: "expected ok flag".to_string(),
+            }
+        );
+        assert!(!error.to_string().contains("secret"));
+        assert!(!error.to_string().contains("value"));
+    }
+
+    #[test]
+    fn in_memory_registry_rejects_descriptor_only_create() {
+        let registry = InMemoryTaskRegistry::from_descriptors([explicit_descriptor(
+            "acme.task",
+            "1.0.0",
+            false,
+        )])
+        .expect("descriptor should register");
+
+        let error = registry
+            .create("acme.task", None, Value::Null)
+            .err()
+            .expect("descriptor-only entry is not constructible");
+
+        assert_eq!(
+            error,
+            TaskRegistrationError::NotConstructible {
+                id: "acme.task".to_string(),
+                version: "1.0.0".to_string(),
+            }
         );
     }
 }

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -8,6 +8,298 @@
 use super::{RetryConfig, TaskExecutionMode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::error::Error;
+use std::fmt;
+
+/// Errors returned by task registration, discovery, and construction APIs.
+///
+/// Factory and input errors identify the affected task but intentionally carry
+/// sanitized messages instead of raw JSON input values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskRegistrationError {
+    /// A stable explicit task ID failed validation.
+    InvalidId {
+        /// Invalid ID value.
+        id: String,
+        /// Human-readable validation failure.
+        reason: String,
+    },
+    /// A task version failed semantic-version validation.
+    InvalidVersion {
+        /// Invalid version value.
+        version: String,
+        /// Human-readable validation failure.
+        reason: String,
+    },
+    /// A rendered task identity failed `<task-id>@<task-version>` parsing.
+    InvalidIdentity {
+        /// Invalid identity value.
+        identity: String,
+        /// Human-readable parsing failure.
+        reason: String,
+    },
+    /// A registry already contains the same task ID and version.
+    DuplicateRegistration {
+        /// Duplicate task ID.
+        id: String,
+        /// Duplicate task version.
+        version: String,
+    },
+    /// No task matched the requested ID and optional version.
+    NotFound {
+        /// Requested task ID.
+        id: String,
+        /// Requested version, if the caller specified one.
+        version: Option<String>,
+    },
+    /// A lookup by ID omitted the version and multiple versions are available.
+    AmbiguousVersion {
+        /// Requested task ID.
+        id: String,
+        /// Available versions for that ID.
+        versions: Vec<String>,
+    },
+    /// The task is discoverable but cannot be constructed from local JSON input.
+    NotConstructible {
+        /// Task ID.
+        id: String,
+        /// Task version.
+        version: String,
+    },
+    /// JSON-compatible task input failed validation or deserialization.
+    InvalidInput {
+        /// Task ID.
+        id: String,
+        /// Task version.
+        version: String,
+        /// Sanitized error message.
+        message: String,
+    },
+    /// A task factory failed after receiving structurally valid input.
+    FactoryFailed {
+        /// Task ID.
+        id: String,
+        /// Task version.
+        version: String,
+        /// Sanitized error message.
+        message: String,
+    },
+}
+
+impl fmt::Display for TaskRegistrationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidId { id, reason } => {
+                write!(f, "invalid task id `{id}`: {reason}")
+            }
+            Self::InvalidVersion { version, reason } => {
+                write!(f, "invalid task version `{version}`: {reason}")
+            }
+            Self::InvalidIdentity { identity, reason } => {
+                write!(f, "invalid task identity `{identity}`: {reason}")
+            }
+            Self::DuplicateRegistration { id, version } => {
+                write!(f, "duplicate task registration `{id}@{version}`")
+            }
+            Self::NotFound { id, version } => match version {
+                Some(version) => write!(f, "registered task `{id}@{version}` was not found"),
+                None => write!(f, "registered task `{id}` was not found"),
+            },
+            Self::AmbiguousVersion { id, versions } => {
+                write!(
+                    f,
+                    "registered task `{id}` has multiple versions: {}",
+                    versions.join(", ")
+                )
+            }
+            Self::NotConstructible { id, version } => {
+                write!(f, "registered task `{id}@{version}` is not constructible")
+            }
+            Self::InvalidInput {
+                id,
+                version,
+                message,
+            } => {
+                write!(
+                    f,
+                    "invalid input for registered task `{id}@{version}`: {message}"
+                )
+            }
+            Self::FactoryFailed {
+                id,
+                version,
+                message,
+            } => {
+                write!(
+                    f,
+                    "factory failed for registered task `{id}@{version}`: {message}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for TaskRegistrationError {}
+
+/// Stable task registration identity.
+///
+/// A `TaskRegistrationKey` renders as `<task-id>@<task-version>`, for example
+/// `acme.network.configure_acl@2.0.0`. It validates IDs using the explicit
+/// stable task ID rules and versions using semantic-version parsing.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TaskRegistrationKey {
+    id: String,
+    version: String,
+}
+
+impl TaskRegistrationKey {
+    /// Create a validated stable task registration key.
+    pub fn new(
+        id: impl Into<String>,
+        version: impl Into<String>,
+    ) -> Result<Self, TaskRegistrationError> {
+        let id = id.into();
+        let version = version.into();
+        validate_explicit_task_id(&id)?;
+        validate_task_version(&version)?;
+        Ok(Self { id, version })
+    }
+
+    /// Parse a stable task identity in `<task-id>@<task-version>` form.
+    pub fn parse(identity: &str) -> Result<Self, TaskRegistrationError> {
+        if identity.is_empty() {
+            return Err(TaskRegistrationError::InvalidIdentity {
+                identity: identity.to_string(),
+                reason: "identity must not be empty".to_string(),
+            });
+        }
+
+        if identity.matches('@').count() != 1 {
+            return Err(TaskRegistrationError::InvalidIdentity {
+                identity: identity.to_string(),
+                reason: "identity must contain exactly one `@` separator".to_string(),
+            });
+        }
+
+        let (id, version) =
+            identity
+                .split_once('@')
+                .ok_or_else(|| TaskRegistrationError::InvalidIdentity {
+                    identity: identity.to_string(),
+                    reason: "identity must contain exactly one `@` separator".to_string(),
+                })?;
+
+        if id.is_empty() {
+            return Err(TaskRegistrationError::InvalidIdentity {
+                identity: identity.to_string(),
+                reason: "identity must include a task id before `@`".to_string(),
+            });
+        }
+
+        if version.is_empty() {
+            return Err(TaskRegistrationError::InvalidIdentity {
+                identity: identity.to_string(),
+                reason: "identity must include a task version after `@`".to_string(),
+            });
+        }
+
+        Self::new(id, version)
+    }
+
+    /// Return the stable task ID.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Return the task contract version.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
+
+impl fmt::Display for TaskRegistrationKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.id, self.version)
+    }
+}
+
+/// Validate an explicitly authored stable task ID.
+///
+/// Explicit IDs are namespace-friendly identifiers made of one or more `.`
+/// separated segments. Segment characters must be ASCII lowercase letters,
+/// digits, `_`, or `-`; every segment must start with a letter or digit.
+pub fn validate_explicit_task_id(id: &str) -> Result<(), TaskRegistrationError> {
+    let invalid = |reason: &str| TaskRegistrationError::InvalidId {
+        id: id.to_string(),
+        reason: reason.to_string(),
+    };
+
+    if id.is_empty() {
+        return Err(invalid("id must not be empty"));
+    }
+
+    if id.trim() != id {
+        return Err(invalid("id must not have leading or trailing whitespace"));
+    }
+
+    if id.contains('@') {
+        return Err(invalid("id must not contain `@`"));
+    }
+
+    for segment in id.split('.') {
+        validate_task_id_segment(id, segment)?;
+    }
+
+    Ok(())
+}
+
+fn validate_task_id_segment(id: &str, segment: &str) -> Result<(), TaskRegistrationError> {
+    let invalid = |reason: &str| TaskRegistrationError::InvalidId {
+        id: id.to_string(),
+        reason: reason.to_string(),
+    };
+
+    if segment.is_empty() {
+        return Err(invalid("id segments must not be empty"));
+    }
+
+    let first = segment
+        .bytes()
+        .next()
+        .expect("segment is known to be non-empty");
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return Err(invalid(
+            "id segments must start with an ASCII lowercase letter or digit",
+        ));
+    }
+
+    if !segment.bytes().all(|byte| {
+        byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' || byte == b'-'
+    }) {
+        return Err(invalid(
+            "id segments may contain only ASCII lowercase letters, digits, `_`, or `-`",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate a task contract version as a semantic version.
+pub fn validate_task_version(version: &str) -> Result<(), TaskRegistrationError> {
+    if version.is_empty() {
+        return Err(TaskRegistrationError::InvalidVersion {
+            version: version.to_string(),
+            reason: "version must not be empty".to_string(),
+        });
+    }
+
+    semver::Version::parse(version).map_err(|error| TaskRegistrationError::InvalidVersion {
+        version: version.to_string(),
+        reason: error.to_string(),
+    })?;
+
+    Ok(())
+}
 
 /// Indicates how a task descriptor's `id` was chosen.
 ///
@@ -329,6 +621,187 @@ mod tests {
                 &["audit".to_string()][..],
                 None,
             )
+        );
+    }
+
+    #[test]
+    fn explicit_task_id_validation_accepts_namespace_friendly_ids() {
+        for id in [
+            "configure_acl",
+            "acme.network.configure_acl",
+            "io.github.acme.configure-acl",
+            "a1.b2.c3",
+            "1stage.configure_acl",
+        ] {
+            validate_explicit_task_id(id).expect("id should be valid");
+        }
+    }
+
+    #[test]
+    fn explicit_task_id_validation_rejects_unstable_or_malformed_ids() {
+        for (id, expected_reason) in [
+            ("", "id must not be empty"),
+            (
+                " acme.network.configure_acl",
+                "id must not have leading or trailing whitespace",
+            ),
+            (
+                "acme.network.configure_acl ",
+                "id must not have leading or trailing whitespace",
+            ),
+            ("acme.network@configure_acl", "id must not contain `@`"),
+            ("acme..network", "id segments must not be empty"),
+            ("acme.network.", "id segments must not be empty"),
+            (
+                "Acme.network",
+                "id segments must start with an ASCII lowercase letter or digit",
+            ),
+            (
+                "_acme.network",
+                "id segments must start with an ASCII lowercase letter or digit",
+            ),
+            (
+                "acme.network/configure_acl",
+                "id segments may contain only ASCII lowercase letters, digits, `_`, or `-`",
+            ),
+        ] {
+            let error = validate_explicit_task_id(id).expect_err("id should be invalid");
+            assert_eq!(
+                error,
+                TaskRegistrationError::InvalidId {
+                    id: id.to_string(),
+                    reason: expected_reason.to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn task_version_validation_accepts_semver_versions() {
+        for version in ["1.0.0", "2.1.3", "1.0.0-alpha.1", "1.0.0+build.1"] {
+            validate_task_version(version).expect("version should be valid");
+        }
+    }
+
+    #[test]
+    fn task_version_validation_rejects_non_semver_versions() {
+        for version in ["", "1", "latest", "v1.0.0"] {
+            let error = validate_task_version(version).expect_err("version should be invalid");
+            assert!(matches!(
+                error,
+                TaskRegistrationError::InvalidVersion { .. }
+            ));
+            assert!(
+                error.to_string().contains(version),
+                "error should identify the invalid version"
+            );
+        }
+    }
+
+    #[test]
+    fn registration_key_new_validates_and_exposes_parts() {
+        let key = TaskRegistrationKey::new("acme.network.configure_acl", "2.0.0")
+            .expect("key should be valid");
+
+        assert_eq!(key.id(), "acme.network.configure_acl");
+        assert_eq!(key.version(), "2.0.0");
+        assert_eq!(key.to_string(), "acme.network.configure_acl@2.0.0");
+    }
+
+    #[test]
+    fn registration_key_parse_round_trips_display() {
+        let parsed = TaskRegistrationKey::parse("acme.network.configure_acl@2.0.0")
+            .expect("identity should parse");
+
+        assert_eq!(parsed.id(), "acme.network.configure_acl");
+        assert_eq!(parsed.version(), "2.0.0");
+        assert_eq!(
+            TaskRegistrationKey::parse(&parsed.to_string()).expect("display should parse"),
+            parsed
+        );
+    }
+
+    #[test]
+    fn registration_key_parse_rejects_invalid_separator_shapes() {
+        for (identity, expected_reason) in [
+            ("", "identity must not be empty"),
+            (
+                "acme.network.configure_acl",
+                "identity must contain exactly one `@` separator",
+            ),
+            (
+                "acme.network.configure_acl@2.0.0@extra",
+                "identity must contain exactly one `@` separator",
+            ),
+            ("@2.0.0", "identity must include a task id before `@`"),
+            (
+                "acme.network.configure_acl@",
+                "identity must include a task version after `@`",
+            ),
+        ] {
+            let error = TaskRegistrationKey::parse(identity).expect_err("identity should fail");
+            assert_eq!(
+                error,
+                TaskRegistrationError::InvalidIdentity {
+                    identity: identity.to_string(),
+                    reason: expected_reason.to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn registration_key_parse_reuses_id_and_version_validation() {
+        assert!(matches!(
+            TaskRegistrationKey::parse("Acme.network.configure_acl@2.0.0"),
+            Err(TaskRegistrationError::InvalidId { .. })
+        ));
+
+        assert!(matches!(
+            TaskRegistrationKey::parse("acme.network.configure_acl@latest"),
+            Err(TaskRegistrationError::InvalidVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn registration_error_display_identifies_task_without_raw_input() {
+        let error = TaskRegistrationError::InvalidInput {
+            id: "acme.network.configure_acl".to_string(),
+            version: "2.0.0".to_string(),
+            message: "missing field `acl_name`".to_string(),
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "invalid input for registered task `acme.network.configure_acl@2.0.0`: missing field `acl_name`"
+        );
+    }
+
+    #[test]
+    fn registration_error_display_handles_lookup_and_registry_errors() {
+        assert_eq!(
+            TaskRegistrationError::DuplicateRegistration {
+                id: "acme.network.configure_acl".to_string(),
+                version: "2.0.0".to_string(),
+            }
+            .to_string(),
+            "duplicate task registration `acme.network.configure_acl@2.0.0`"
+        );
+        assert_eq!(
+            TaskRegistrationError::NotFound {
+                id: "acme.network.configure_acl".to_string(),
+                version: None,
+            }
+            .to_string(),
+            "registered task `acme.network.configure_acl` was not found"
+        );
+        assert_eq!(
+            TaskRegistrationError::AmbiguousVersion {
+                id: "acme.network.configure_acl".to_string(),
+                versions: vec!["1.0.0".to_string(), "2.0.0".to_string()],
+            }
+            .to_string(),
+            "registered task `acme.network.configure_acl` has multiple versions: 1.0.0, 2.0.0"
         );
     }
 }

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -1643,8 +1643,7 @@ mod tests {
 
         let error = registry
             .create("acme.task", Some("1.0.0"), json!({ "secret": "value" }))
-            .err()
-            .expect("factory should reject input");
+            .expect_err("factory should reject input");
 
         assert_eq!(
             error,
@@ -1669,8 +1668,7 @@ mod tests {
 
         let error = registry
             .create("acme.task", None, Value::Null)
-            .err()
-            .expect("descriptor-only entry is not constructible");
+            .expect_err("descriptor-only entry is not constructible");
 
         assert_eq!(
             error,

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -399,6 +399,21 @@ pub fn get_compiled_task_descriptor(
     compiled_task_registry()?.get(id, version)
 }
 
+/// Look up a compiled task descriptor by rendered `<task-id>@<task-version>` identity.
+pub fn get_compiled_task_descriptor_by_identity(
+    identity: &str,
+) -> Result<TaskDescriptor, TaskRegistrationError> {
+    compiled_task_registry()?.get_by_identity(identity)
+}
+
+/// Construct a compiled task by rendered `<task-id>@<task-version>` identity.
+pub fn create_compiled_task_by_identity(
+    identity: &str,
+    input: Value,
+) -> Result<TaskDefinition, TaskRegistrationError> {
+    compiled_task_registry()?.create_by_identity(identity, input)
+}
+
 /// Read-only catalog of task descriptors.
 ///
 /// Catalog implementations provide metadata listing and lookup. They do not
@@ -416,6 +431,20 @@ pub trait TaskCatalog {
     /// [`TaskRegistrationError::AmbiguousVersion`].
     fn get(&self, id: &str, version: Option<&str>)
     -> Result<TaskDescriptor, TaskRegistrationError>;
+
+    /// Look up a descriptor by validated task registration key.
+    fn get_by_key(
+        &self,
+        key: &TaskRegistrationKey,
+    ) -> Result<TaskDescriptor, TaskRegistrationError> {
+        self.get(key.id(), Some(key.version()))
+    }
+
+    /// Parse `<task-id>@<task-version>` and look up the matching descriptor.
+    fn get_by_identity(&self, identity: &str) -> Result<TaskDescriptor, TaskRegistrationError> {
+        let key = TaskRegistrationKey::parse(identity)?;
+        self.get_by_key(&key)
+    }
 }
 
 /// Local factory registry for constructing tasks from JSON-compatible input.
@@ -431,6 +460,25 @@ pub trait TaskFactoryRegistry {
         version: Option<&str>,
         input: Value,
     ) -> Result<TaskDefinition, TaskRegistrationError>;
+
+    /// Construct a local task definition by validated task registration key.
+    fn create_by_key(
+        &self,
+        key: &TaskRegistrationKey,
+        input: Value,
+    ) -> Result<TaskDefinition, TaskRegistrationError> {
+        self.create(key.id(), Some(key.version()), input)
+    }
+
+    /// Parse `<task-id>@<task-version>` and construct the matching task.
+    fn create_by_identity(
+        &self,
+        identity: &str,
+        input: Value,
+    ) -> Result<TaskDefinition, TaskRegistrationError> {
+        let key = TaskRegistrationKey::parse(identity)?;
+        self.create_by_key(&key, input)
+    }
 }
 
 /// Type-erased factory for one registered task.
@@ -1321,6 +1369,43 @@ mod tests {
     }
 
     #[test]
+    fn in_memory_registry_get_by_identity_parses_task_key() {
+        let registry = InMemoryTaskRegistry::from_descriptors([explicit_descriptor(
+            "acme.task",
+            "1.0.0",
+            false,
+        )])
+        .expect("descriptors should register");
+
+        let descriptor = registry
+            .get_by_identity("acme.task@1.0.0")
+            .expect("identity lookup should succeed");
+
+        assert_eq!(descriptor.id, "acme.task");
+        assert_eq!(descriptor.version, "1.0.0");
+    }
+
+    #[test]
+    fn in_memory_registry_get_by_identity_rejects_invalid_identity() {
+        let registry = InMemoryTaskRegistry::from_descriptors([explicit_descriptor(
+            "acme.task",
+            "1.0.0",
+            false,
+        )])
+        .expect("descriptors should register");
+
+        assert_eq!(
+            registry
+                .get_by_identity("acme.task")
+                .expect_err("invalid identity should fail"),
+            TaskRegistrationError::InvalidIdentity {
+                identity: "acme.task".to_string(),
+                reason: "identity must contain exactly one `@` separator".to_string(),
+            }
+        );
+    }
+
+    #[test]
     fn in_memory_registry_rejects_duplicate_id_and_version() {
         let error = InMemoryTaskRegistry::from_descriptors([
             explicit_descriptor("acme.task", "1.0.0", false),
@@ -1377,6 +1462,20 @@ mod tests {
         let task = registry
             .create("acme.task", None, json!({ "ok": true }))
             .expect("factory should create task");
+
+        assert_eq!(task.as_task().name(), "registry_test_task");
+    }
+
+    #[test]
+    fn in_memory_registry_create_by_identity_parses_task_key() {
+        let mut registry = InMemoryTaskRegistry::new();
+        registry
+            .register_factory(RegistryTestFactory::new("acme.task", "1.0.0"))
+            .expect("factory should register");
+
+        let task = registry
+            .create_by_identity("acme.task@1.0.0", json!({ "ok": true }))
+            .expect("identity create should succeed");
 
         assert_eq!(task.as_task().name(), "registry_test_task");
     }

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -5,6 +5,125 @@
 //! Python registration integrations. Descriptors can be stored by themselves
 //! for discovery-only catalogs or paired with factories that construct local
 //! task instances from JSON-compatible input.
+//!
+//! # Registration model
+//!
+//! Task discovery is descriptor-first. A [`TaskDescriptor`] contains the
+//! language-neutral metadata needed to list and inspect a task without running
+//! it. A [`RegisteredTaskFactory`] is optional local code that can construct a
+//! [`TaskDefinition`] from JSON-compatible input. [`TaskCatalog`] covers the
+//! descriptor-only side; [`TaskFactoryRegistry`] covers local construction.
+//!
+//! Rust tasks normally enter the compiled registry through the
+//! `#[genja_task]` macro. A task without `registration(...)` is still
+//! discoverable with a generated local ID, but it is not constructible from
+//! JSON input. A task with `registration(id = "...")` gets an explicit stable
+//! ID and a generated factory.
+//!
+//! # Task identity
+//!
+//! A registered task's public identity is:
+//!
+//! ```text
+//! <task-id>@<task-version>
+//! ```
+//!
+//! For example:
+//!
+//! ```text
+//! acme.network.configure_acl@2.0.0
+//! ```
+//!
+//! Explicit task IDs are namespace-friendly strings made of `.` separated
+//! segments. Versions must be semantic versions. When a macro registration
+//! omits `version`, it uses the provider crate's `CARGO_PKG_VERSION`.
+//! Duplicate `id + version` registrations are rejected while the registry is
+//! built.
+//!
+//! # Listing compiled tasks
+//!
+//! ```no_run
+//! use genja_core::task::list_compiled_tasks;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! for descriptor in list_compiled_tasks()? {
+//!     println!(
+//!         "{}@{} {}",
+//!         descriptor.id,
+//!         descriptor.version,
+//!         descriptor.name
+//!     );
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Generated IDs start with `auto:` and are intended for local discovery only.
+//! Provider manifests, CLIs, MCP servers, and remote catalogs should use
+//! explicit IDs from `registration(id = "...")`.
+//!
+//! # Looking up and constructing a compiled task
+//!
+//! Use descriptor lookup when you only need metadata:
+//!
+//! ```no_run
+//! use genja_core::task::get_compiled_task_descriptor_by_identity;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let descriptor =
+//!     get_compiled_task_descriptor_by_identity("acme.network.configure_acl@2.0.0")?;
+//!
+//! if let Some(schema) = &descriptor.input_schema {
+//!     println!("{}", serde_json::to_string_pretty(schema)?);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Use the factory registry path when a caller supplied JSON input and you need
+//! a runnable [`TaskDefinition`]:
+//!
+//! ```no_run
+//! use genja_core::task::{TaskInfo, create_compiled_task_by_identity};
+//! use serde_json::json;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let task = create_compiled_task_by_identity(
+//!     "acme.network.configure_acl@2.0.0",
+//!     json!({
+//!         "acl_name": "edge-inbound",
+//!         "rules": []
+//!     }),
+//! )?;
+//!
+//! assert_eq!(task.name(), "configure_acl");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Factory and validation errors identify the affected task identity but should
+//! not expose raw input values or decoded secret material.
+//!
+//! # Descriptor JSON
+//!
+//! Descriptors serialize with stable field names suitable for future provider
+//! manifests and cross-language compatibility tests:
+//!
+//! ```json
+//! {
+//!   "id": "acme.network.configure_acl",
+//!   "id_source": "explicit",
+//!   "name": "configure_acl",
+//!   "version": "2.0.0",
+//!   "description": "Configures an ACL on a network device",
+//!   "execution_mode": "async",
+//!   "connection_plugin_name": "ssh",
+//!   "processor_names": [],
+//!   "retry": null,
+//!   "input_schema": null,
+//!   "constructible": true
+//! }
+//! ```
 
 use super::{RetryConfig, TaskDefinition, TaskExecutionMode};
 use serde::{Deserialize, Serialize};
@@ -400,6 +519,10 @@ pub fn get_compiled_task_descriptor(
 }
 
 /// Look up a compiled task descriptor by rendered `<task-id>@<task-version>` identity.
+///
+/// This is the most convenient lookup form for CLIs and APIs that accept a
+/// single task identity string. The identity is parsed with
+/// [`TaskRegistrationKey::parse`] before querying the compiled catalog.
 pub fn get_compiled_task_descriptor_by_identity(
     identity: &str,
 ) -> Result<TaskDescriptor, TaskRegistrationError> {
@@ -407,6 +530,11 @@ pub fn get_compiled_task_descriptor_by_identity(
 }
 
 /// Construct a compiled task by rendered `<task-id>@<task-version>` identity.
+///
+/// This helper validates the identity, finds the compiled factory, and passes
+/// `input` to the task's selected construction strategy. Descriptor-only tasks
+/// and generated local discovery entries return
+/// [`TaskRegistrationError::NotConstructible`].
 pub fn create_compiled_task_by_identity(
     identity: &str,
     input: Value,
@@ -422,6 +550,9 @@ pub fn create_compiled_task_by_identity(
 /// without supporting in-process task construction.
 pub trait TaskCatalog {
     /// Return all known task descriptors in deterministic order.
+    ///
+    /// Implementations should order descriptors by task ID and version so CLI,
+    /// manifest, and test output is stable.
     fn list(&self) -> Result<Vec<TaskDescriptor>, TaskRegistrationError>;
 
     /// Look up a descriptor by ID and optional version.
@@ -433,6 +564,9 @@ pub trait TaskCatalog {
     -> Result<TaskDescriptor, TaskRegistrationError>;
 
     /// Look up a descriptor by validated task registration key.
+    ///
+    /// Use this when the caller has already parsed or validated
+    /// `<task-id>@<task-version>`.
     fn get_by_key(
         &self,
         key: &TaskRegistrationKey,
@@ -441,6 +575,9 @@ pub trait TaskCatalog {
     }
 
     /// Parse `<task-id>@<task-version>` and look up the matching descriptor.
+    ///
+    /// Use this form for user-facing inputs such as CLI arguments and MCP tool
+    /// parameters.
     fn get_by_identity(&self, identity: &str) -> Result<TaskDescriptor, TaskRegistrationError> {
         let key = TaskRegistrationKey::parse(identity)?;
         self.get_by_key(&key)
@@ -451,9 +588,14 @@ pub trait TaskCatalog {
 ///
 /// This trait is intentionally separate from [`TaskCatalog`] because persistent
 /// catalogs can store descriptors but cannot store Rust function pointers or
-/// closures.
+/// closures. Local registries, including the compiled registry, can implement
+/// both traits.
 pub trait TaskFactoryRegistry {
     /// Construct a local task definition by ID, optional version, and input.
+    ///
+    /// When `version` is `None`, construction succeeds only if exactly one
+    /// version exists for `id`. If the descriptor is present but not backed by
+    /// a factory, the registry returns [`TaskRegistrationError::NotConstructible`].
     fn create(
         &self,
         id: &str,
@@ -462,6 +604,8 @@ pub trait TaskFactoryRegistry {
     ) -> Result<TaskDefinition, TaskRegistrationError>;
 
     /// Construct a local task definition by validated task registration key.
+    ///
+    /// Use this when the caller already has a [`TaskRegistrationKey`].
     fn create_by_key(
         &self,
         key: &TaskRegistrationKey,
@@ -471,6 +615,9 @@ pub trait TaskFactoryRegistry {
     }
 
     /// Parse `<task-id>@<task-version>` and construct the matching task.
+    ///
+    /// This is the most direct form for CLI, MCP, and API entrypoints that
+    /// receive a task identity string plus JSON input.
     fn create_by_identity(
         &self,
         identity: &str,
@@ -485,12 +632,19 @@ pub trait TaskFactoryRegistry {
 ///
 /// Macro-generated registrations will implement this trait for each
 /// constructible task. The registry only calls this common interface; the
-/// factory implementation owns the task-specific construction strategy.
+/// factory implementation owns the task-specific construction strategy. Manual
+/// implementations should validate input without including raw secrets in
+/// returned error messages.
 pub trait RegisteredTaskFactory: Send + Sync {
     /// Return the descriptor for the task this factory constructs.
     fn descriptor(&self) -> &TaskDescriptor;
 
     /// Construct a task definition from JSON-compatible input.
+    ///
+    /// Implementations should return [`TaskRegistrationError::InvalidInput`]
+    /// for caller-supplied input that does not match the task contract and
+    /// [`TaskRegistrationError::FactoryFailed`] for construction failures after
+    /// input validation.
     fn create(&self, input: Value) -> Result<TaskDefinition, TaskRegistrationError>;
 }
 

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -2,8 +2,9 @@
 //!
 //! This module defines the serializable task descriptor contract used by
 //! local Rust task discovery and future catalog, provider manifest, MCP, and
-//! Python registration integrations. The descriptor is metadata only; local
-//! construction from JSON input is handled by later factory registry APIs.
+//! Python registration integrations. Descriptors can be stored by themselves
+//! for discovery-only catalogs or paired with factories that construct local
+//! task instances from JSON-compatible input.
 
 use super::{RetryConfig, TaskDefinition, TaskExecutionMode};
 use serde::{Deserialize, Serialize};
@@ -311,6 +312,7 @@ pub fn validate_task_version(version: &str) -> Result<(), TaskRegistrationError>
 /// `String`, `Vec`, and JSON values without requiring const allocation.
 pub struct CompiledTaskRegistration {
     descriptor: fn() -> TaskDescriptor,
+    create: Option<fn(Value) -> Result<TaskDefinition, TaskRegistrationError>>,
 }
 
 impl CompiledTaskRegistration {
@@ -319,7 +321,25 @@ impl CompiledTaskRegistration {
     /// Descriptor-only registrations are discoverable through [`TaskCatalog`]
     /// but are not constructible through [`TaskFactoryRegistry`].
     pub const fn descriptor_only(descriptor: fn() -> TaskDescriptor) -> Self {
-        Self { descriptor }
+        Self {
+            descriptor,
+            create: None,
+        }
+    }
+
+    /// Create a constructible compiled task registration.
+    ///
+    /// Constructible registrations are discoverable through [`TaskCatalog`] and
+    /// can be created from JSON-compatible input through
+    /// [`TaskFactoryRegistry::create`].
+    pub const fn constructible(
+        descriptor: fn() -> TaskDescriptor,
+        create: fn(Value) -> Result<TaskDefinition, TaskRegistrationError>,
+    ) -> Self {
+        Self {
+            descriptor,
+            create: Some(create),
+        }
     }
 
     /// Build this registration's task descriptor.
@@ -330,6 +350,21 @@ impl CompiledTaskRegistration {
 
 inventory_crate::collect!(CompiledTaskRegistration);
 
+struct CompiledTaskFactory {
+    descriptor: TaskDescriptor,
+    create: fn(Value) -> Result<TaskDefinition, TaskRegistrationError>,
+}
+
+impl RegisteredTaskFactory for CompiledTaskFactory {
+    fn descriptor(&self) -> &TaskDescriptor {
+        &self.descriptor
+    }
+
+    fn create(&self, input: Value) -> Result<TaskDefinition, TaskRegistrationError> {
+        (self.create)(input)
+    }
+}
+
 /// Build an in-memory registry from all task registrations linked into this process.
 ///
 /// The resulting registry validates descriptor versions, validates explicit
@@ -338,7 +373,12 @@ inventory_crate::collect!(CompiledTaskRegistration);
 pub fn compiled_task_registry() -> Result<InMemoryTaskRegistry, TaskRegistrationError> {
     let mut registry = InMemoryTaskRegistry::new();
     for registration in inventory_crate::iter::<CompiledTaskRegistration> {
-        registry.register_descriptor(registration.descriptor())?;
+        let descriptor = registration.descriptor();
+        if let Some(create) = registration.create {
+            registry.register_factory(CompiledTaskFactory { descriptor, create })?;
+        } else {
+            registry.register_descriptor(descriptor)?;
+        }
     }
     Ok(registry)
 }

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -1,0 +1,155 @@
+//! Task registration and discovery descriptor types.
+//!
+//! This module defines the serializable task descriptor contract used by
+//! local Rust task discovery and future catalog, provider manifest, MCP, and
+//! Python registration integrations. The descriptor is metadata only; local
+//! construction from JSON input is handled by later factory registry APIs.
+
+use super::{RetryConfig, TaskExecutionMode};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Indicates how a task descriptor's `id` was chosen.
+///
+/// Generated IDs are useful for local discovery but are derived from Rust
+/// implementation details such as type and module paths, so they are not a
+/// stable public contract. Explicit IDs are authored by the task provider and
+/// are intended to remain stable across implementation refactors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskIdSource {
+    /// The task ID was generated from implementation metadata.
+    Generated,
+    /// The task ID was explicitly declared by the task author.
+    Explicit,
+}
+
+/// Serializable metadata describing a discoverable task.
+///
+/// `TaskDescriptor` is the canonical Rust-side shape for task discovery. It is
+/// designed to be language-neutral so future Python registration, persistent
+/// catalogs, provider manifests, and MCP tooling can consume equivalent JSON.
+///
+/// A descriptor's public identity is the pair of [`TaskDescriptor::id`] and
+/// [`TaskDescriptor::version`], rendered as `<task-id>@<task-version>` by
+/// higher-level catalog APIs. Generated IDs should be treated as local-only;
+/// explicit IDs are the stable form intended for provider and remote catalog
+/// workflows.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskDescriptor {
+    /// Stable or generated task identifier.
+    pub id: String,
+    /// Whether the task ID was generated or explicitly authored.
+    pub id_source: TaskIdSource,
+    /// Human-readable task name reused from task metadata.
+    pub name: String,
+    /// Task contract version.
+    pub version: String,
+    /// Optional human-readable task description.
+    pub description: Option<String>,
+    /// Whether the task uses blocking or async execution.
+    pub execution_mode: TaskExecutionMode,
+    /// Connection plugin required by the task, if any.
+    pub connection_plugin_name: Option<String>,
+    /// Processor plugins selected by the task.
+    pub processor_names: Vec<String>,
+    /// Task-specific retry metadata, if configured.
+    pub retry: Option<RetryConfig>,
+    /// Optional JSON Schema describing accepted construction input.
+    pub input_schema: Option<Value>,
+    /// Whether this process can construct the task from JSON-compatible input.
+    pub constructible: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn descriptor_serializes_to_canonical_field_names() {
+        let descriptor = TaskDescriptor {
+            id: "acme.network.configure_acl".to_string(),
+            id_source: TaskIdSource::Explicit,
+            name: "configure_acl".to_string(),
+            version: "2.0.0".to_string(),
+            description: Some("Configures an ACL on a network device".to_string()),
+            execution_mode: TaskExecutionMode::Async,
+            connection_plugin_name: Some("ssh".to_string()),
+            processor_names: vec!["audit".to_string()],
+            retry: Some(RetryConfig::builder().allow(true).max_attempts(3).build()),
+            input_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "acl_name": { "type": "string" }
+                }
+            })),
+            constructible: true,
+        };
+
+        let serialized = serde_json::to_value(&descriptor).expect("descriptor serializes");
+
+        assert_eq!(
+            serialized,
+            json!({
+                "id": "acme.network.configure_acl",
+                "id_source": "explicit",
+                "name": "configure_acl",
+                "version": "2.0.0",
+                "description": "Configures an ACL on a network device",
+                "execution_mode": "async",
+                "connection_plugin_name": "ssh",
+                "processor_names": ["audit"],
+                "retry": {
+                    "allow": true,
+                    "max_attempts": 3,
+                    "delay_ms": null
+                },
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "acl_name": { "type": "string" }
+                    }
+                },
+                "constructible": true
+            })
+        );
+    }
+
+    #[test]
+    fn descriptor_serializes_empty_optional_metadata_as_nulls_and_lists() {
+        let descriptor = TaskDescriptor {
+            id: "auto:acme_network_tasks::network::ConfigureAcl".to_string(),
+            id_source: TaskIdSource::Generated,
+            name: "configure_acl".to_string(),
+            version: "2.0.0".to_string(),
+            description: None,
+            execution_mode: TaskExecutionMode::Blocking,
+            connection_plugin_name: None,
+            processor_names: Vec::new(),
+            retry: None,
+            input_schema: None,
+            constructible: false,
+        };
+
+        let serialized = serde_json::to_value(&descriptor).expect("descriptor serializes");
+
+        assert_eq!(
+            serialized,
+            json!({
+                "id": "auto:acme_network_tasks::network::ConfigureAcl",
+                "id_source": "generated",
+                "name": "configure_acl",
+                "version": "2.0.0",
+                "description": null,
+                "execution_mode": "blocking",
+                "connection_plugin_name": null,
+                "processor_names": [],
+                "retry": null,
+                "input_schema": null,
+                "constructible": false
+            })
+        );
+    }
+}

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -303,6 +303,62 @@ pub fn validate_task_version(version: &str) -> Result<(), TaskRegistrationError>
     Ok(())
 }
 
+/// A task registration entry collected from compiled Rust code.
+///
+/// `#[genja_task]` uses this type to submit descriptor builders into the
+/// process-wide compiled task inventory. It stores function pointers rather
+/// than fully built descriptors so macro-generated descriptors can use owned
+/// `String`, `Vec`, and JSON values without requiring const allocation.
+pub struct CompiledTaskRegistration {
+    descriptor: fn() -> TaskDescriptor,
+}
+
+impl CompiledTaskRegistration {
+    /// Create a descriptor-only compiled task registration.
+    ///
+    /// Descriptor-only registrations are discoverable through [`TaskCatalog`]
+    /// but are not constructible through [`TaskFactoryRegistry`].
+    pub const fn descriptor_only(descriptor: fn() -> TaskDescriptor) -> Self {
+        Self { descriptor }
+    }
+
+    /// Build this registration's task descriptor.
+    pub fn descriptor(&self) -> TaskDescriptor {
+        (self.descriptor)()
+    }
+}
+
+inventory_crate::collect!(CompiledTaskRegistration);
+
+/// Build an in-memory registry from all task registrations linked into this process.
+///
+/// The resulting registry validates descriptor versions, validates explicit
+/// IDs, rejects duplicate `id + version` pairs, and returns deterministic
+/// listing/lookup behavior. Inventory iteration order is intentionally ignored.
+pub fn compiled_task_registry() -> Result<InMemoryTaskRegistry, TaskRegistrationError> {
+    let mut registry = InMemoryTaskRegistry::new();
+    for registration in inventory_crate::iter::<CompiledTaskRegistration> {
+        registry.register_descriptor(registration.descriptor())?;
+    }
+    Ok(registry)
+}
+
+/// List descriptors for all task registrations linked into this process.
+pub fn list_compiled_tasks() -> Result<Vec<TaskDescriptor>, TaskRegistrationError> {
+    compiled_task_registry()?.list()
+}
+
+/// Look up a compiled task descriptor by ID and optional version.
+///
+/// When `version` is omitted, lookup succeeds only if exactly one version is
+/// available for `id`.
+pub fn get_compiled_task_descriptor(
+    id: &str,
+    version: Option<&str>,
+) -> Result<TaskDescriptor, TaskRegistrationError> {
+    compiled_task_registry()?.get(id, version)
+}
+
 /// Read-only catalog of task descriptors.
 ///
 /// Catalog implementations provide metadata listing and lookup. They do not

--- a/genja-core/src/task/registration.rs
+++ b/genja-core/src/task/registration.rs
@@ -62,31 +62,118 @@ pub struct TaskDescriptor {
     pub constructible: bool,
 }
 
+impl TaskDescriptor {
+    /// Build a descriptor for a task discovered from implementation metadata.
+    ///
+    /// Generated descriptors are useful for local listing and inspection, but
+    /// their IDs are derived from implementation details and should not be
+    /// treated as stable public contracts.
+    pub fn generated(
+        id: impl Into<String>,
+        version: impl Into<String>,
+        metadata: TaskDescriptorMetadata,
+    ) -> Self {
+        Self::from_parts(id, TaskIdSource::Generated, version, metadata, None, false)
+    }
+
+    /// Build a descriptor for a task with an explicitly authored stable ID.
+    ///
+    /// Explicit descriptors represent the stable registration path used by
+    /// future provider manifests, remote catalogs, MCP tooling, and JSON input
+    /// construction.
+    pub fn explicit(
+        id: impl Into<String>,
+        version: impl Into<String>,
+        metadata: TaskDescriptorMetadata,
+        input_schema: Option<Value>,
+        constructible: bool,
+    ) -> Self {
+        Self::from_parts(
+            id,
+            TaskIdSource::Explicit,
+            version,
+            metadata,
+            input_schema,
+            constructible,
+        )
+    }
+
+    fn from_parts(
+        id: impl Into<String>,
+        id_source: TaskIdSource,
+        version: impl Into<String>,
+        metadata: TaskDescriptorMetadata,
+        input_schema: Option<Value>,
+        constructible: bool,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            id_source,
+            name: metadata.name,
+            version: version.into(),
+            description: metadata.description,
+            execution_mode: metadata.execution_mode,
+            connection_plugin_name: metadata.connection_plugin_name,
+            processor_names: metadata.processor_names,
+            retry: metadata.retry,
+            input_schema,
+            constructible,
+        }
+    }
+}
+
+/// Task metadata shared by task runtime metadata and discovery descriptors.
+///
+/// `TaskDescriptorMetadata` keeps descriptor construction aligned with macro
+/// generated [`super::TaskInfo`] metadata. Future macro metadata fields that are
+/// part of task discovery should flow through this struct before they are mapped
+/// into generated or explicit [`TaskDescriptor`] values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskDescriptorMetadata {
+    /// Human-readable task name reused from task metadata.
+    pub name: String,
+    /// Optional human-readable task description.
+    pub description: Option<String>,
+    /// Whether the task uses blocking or async execution.
+    pub execution_mode: TaskExecutionMode,
+    /// Connection plugin required by the task, if any.
+    pub connection_plugin_name: Option<String>,
+    /// Processor plugins selected by the task.
+    pub processor_names: Vec<String>,
+    /// Task-specific retry metadata, if configured.
+    pub retry: Option<RetryConfig>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
-    #[test]
-    fn descriptor_serializes_to_canonical_field_names() {
-        let descriptor = TaskDescriptor {
-            id: "acme.network.configure_acl".to_string(),
-            id_source: TaskIdSource::Explicit,
+    fn descriptor_metadata() -> TaskDescriptorMetadata {
+        TaskDescriptorMetadata {
             name: "configure_acl".to_string(),
-            version: "2.0.0".to_string(),
             description: Some("Configures an ACL on a network device".to_string()),
             execution_mode: TaskExecutionMode::Async,
             connection_plugin_name: Some("ssh".to_string()),
             processor_names: vec!["audit".to_string()],
             retry: Some(RetryConfig::builder().allow(true).max_attempts(3).build()),
-            input_schema: Some(json!({
+        }
+    }
+
+    #[test]
+    fn descriptor_serializes_to_canonical_field_names() {
+        let descriptor = TaskDescriptor::explicit(
+            "acme.network.configure_acl",
+            "2.0.0",
+            descriptor_metadata(),
+            Some(json!({
                 "type": "object",
                 "properties": {
                     "acl_name": { "type": "string" }
                 }
             })),
-            constructible: true,
-        };
+            true,
+        );
 
         let serialized = serde_json::to_value(&descriptor).expect("descriptor serializes");
 
@@ -119,19 +206,18 @@ mod tests {
 
     #[test]
     fn descriptor_serializes_empty_optional_metadata_as_nulls_and_lists() {
-        let descriptor = TaskDescriptor {
-            id: "auto:acme_network_tasks::network::ConfigureAcl".to_string(),
-            id_source: TaskIdSource::Generated,
-            name: "configure_acl".to_string(),
-            version: "2.0.0".to_string(),
-            description: None,
-            execution_mode: TaskExecutionMode::Blocking,
-            connection_plugin_name: None,
-            processor_names: Vec::new(),
-            retry: None,
-            input_schema: None,
-            constructible: false,
-        };
+        let descriptor = TaskDescriptor::generated(
+            "auto:acme_network_tasks::network::ConfigureAcl",
+            "2.0.0",
+            TaskDescriptorMetadata {
+                name: "configure_acl".to_string(),
+                description: None,
+                execution_mode: TaskExecutionMode::Blocking,
+                connection_plugin_name: None,
+                processor_names: Vec::new(),
+                retry: None,
+            },
+        );
 
         let serialized = serde_json::to_value(&descriptor).expect("descriptor serializes");
 
@@ -150,6 +236,99 @@ mod tests {
                 "input_schema": null,
                 "constructible": false
             })
+        );
+    }
+
+    #[test]
+    fn descriptor_constructors_map_shared_metadata() {
+        let metadata = descriptor_metadata();
+
+        let descriptor = TaskDescriptor::explicit(
+            "acme.network.configure_acl",
+            "2.0.0",
+            metadata.clone(),
+            None,
+            true,
+        );
+
+        assert_eq!(descriptor.id, "acme.network.configure_acl");
+        assert_eq!(descriptor.id_source, TaskIdSource::Explicit);
+        assert_eq!(descriptor.version, "2.0.0");
+        assert_eq!(descriptor.name, metadata.name);
+        assert_eq!(descriptor.description, metadata.description);
+        assert_eq!(descriptor.execution_mode, metadata.execution_mode);
+        assert_eq!(
+            descriptor.connection_plugin_name,
+            metadata.connection_plugin_name
+        );
+        assert_eq!(descriptor.processor_names, metadata.processor_names);
+        assert_eq!(descriptor.retry, metadata.retry);
+        assert_eq!(descriptor.input_schema, None);
+        assert!(descriptor.constructible);
+    }
+
+    #[test]
+    fn generated_descriptor_is_not_constructible() {
+        let descriptor = TaskDescriptor::generated(
+            "auto:acme_network_tasks::network::ConfigureAcl",
+            "2.0.0",
+            descriptor_metadata(),
+        );
+
+        assert_eq!(descriptor.id_source, TaskIdSource::Generated);
+        assert_eq!(descriptor.input_schema, None);
+        assert!(!descriptor.constructible);
+    }
+
+    #[test]
+    fn explicit_descriptor_keeps_schema_and_constructible_flag() {
+        let input_schema = json!({
+            "type": "object",
+            "properties": {
+                "acl_name": { "type": "string" }
+            }
+        });
+        let descriptor = TaskDescriptor::explicit(
+            "acme.network.configure_acl",
+            "2.0.0",
+            descriptor_metadata(),
+            Some(input_schema.clone()),
+            true,
+        );
+
+        assert_eq!(descriptor.id_source, TaskIdSource::Explicit);
+        assert_eq!(descriptor.input_schema, Some(input_schema));
+        assert!(descriptor.constructible);
+    }
+
+    #[test]
+    fn descriptor_metadata_can_be_destructured_by_macro_generated_code() {
+        let metadata = TaskDescriptorMetadata {
+            name: "configure_acl".to_string(),
+            description: None,
+            execution_mode: TaskExecutionMode::Async,
+            connection_plugin_name: Some("ssh".to_string()),
+            processor_names: vec!["audit".to_string()],
+            retry: None,
+        };
+
+        assert_eq!(
+            (
+                metadata.name.as_str(),
+                metadata.description.as_deref(),
+                metadata.execution_mode,
+                metadata.connection_plugin_name.as_deref(),
+                metadata.processor_names.as_slice(),
+                metadata.retry,
+            ),
+            (
+                "configure_acl",
+                None,
+                TaskExecutionMode::Async,
+                Some("ssh"),
+                &["audit".to_string()][..],
+                None,
+            )
         );
     }
 }

--- a/genja-core/src/task/spec.rs
+++ b/genja-core/src/task/spec.rs
@@ -2,8 +2,9 @@
 //!
 //! `TaskSpec` is the minimal data model for constructing one registered task
 //! from a stable task identity and JSON-compatible input. It can also carry
-//! narrow per-run runtime policy overrides. It intentionally does not run tasks,
-//! define task lists, or provide a workflow language.
+//! narrow per-run runtime policy overrides for retry and session verification.
+//! It intentionally does not run tasks, define task lists, change processors,
+//! or provide a workflow language.
 
 use super::{
     RetryConfig, SessionVerificationConfig, TaskDefinition, TaskRegistrationError,
@@ -52,6 +53,9 @@ pub enum TaskSpecError {
         message: String,
     },
     /// A task spec override is unsupported or invalid.
+    ///
+    /// Only `retry` and `session_verification` are currently supported under
+    /// `overrides`.
     InvalidOverride {
         /// Override field path.
         field: String,
@@ -144,7 +148,7 @@ impl From<TaskRegistrationError> for TaskSpecConstructionError {
 /// Overrides are intentionally narrow. They can tune runtime policy for a
 /// single constructed task, but they do not rewrite authored task behavior,
 /// change processors, change connection plugins, or alter registration
-/// metadata.
+/// metadata. The supported fields are `retry` and `session_verification`.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaskSpecOverrides {

--- a/genja-core/src/task/spec.rs
+++ b/genja-core/src/task/spec.rs
@@ -1,0 +1,163 @@
+//! Declarative task invocation specs.
+//!
+//! `TaskSpec` is the minimal data model for constructing one registered task
+//! from a stable task identity and JSON-compatible input. It intentionally does
+//! not run tasks, define task lists, apply execution overrides, or provide a
+//! workflow language.
+
+use super::TaskRegistrationKey;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::error::Error;
+use std::fmt;
+
+/// Errors returned while validating declarative task specs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskSpecError {
+    /// The `task` identity failed `<task-id>@<task-version>` validation.
+    InvalidTaskIdentity {
+        /// Invalid identity value.
+        identity: String,
+        /// Human-readable validation failure.
+        reason: String,
+    },
+}
+
+impl fmt::Display for TaskSpecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidTaskIdentity { identity, reason } => {
+                write!(f, "invalid task spec identity `{identity}`: {reason}")
+            }
+        }
+    }
+}
+
+impl Error for TaskSpecError {}
+
+/// Declarative spec for constructing one registered task.
+///
+/// `task` must be a rendered registration identity in
+/// `<task-id>@<task-version>` form. `input` is passed to the registered task
+/// factory as JSON-compatible construction input. When `input` is omitted, it
+/// defaults to an empty object.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskSpec {
+    /// Stable task identity in `<task-id>@<task-version>` form.
+    pub task: String,
+    /// JSON-compatible task construction input.
+    #[serde(default = "empty_input")]
+    pub input: Value,
+}
+
+impl TaskSpec {
+    /// Create and validate a single-task declarative spec.
+    pub fn new(task: impl Into<String>, input: Value) -> Result<Self, TaskSpecError> {
+        let spec = Self {
+            task: task.into(),
+            input,
+        };
+        spec.validate()?;
+        Ok(spec)
+    }
+
+    /// Validate this spec's task identity.
+    pub fn validate(&self) -> Result<(), TaskSpecError> {
+        TaskRegistrationKey::parse(&self.task).map_err(|error| {
+            TaskSpecError::InvalidTaskIdentity {
+                identity: self.task.clone(),
+                reason: error.to_string(),
+            }
+        })?;
+        Ok(())
+    }
+}
+
+fn empty_input() -> Value {
+    Value::Object(Map::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn task_spec_new_accepts_valid_identity_and_input() {
+        let spec = TaskSpec::new(
+            "acme.examples.backup_config@1.0.0",
+            json!({
+                "backup_path": "/tmp/configs",
+                "compress": true,
+            }),
+        )
+        .expect("task spec should be valid");
+
+        assert_eq!(spec.task, "acme.examples.backup_config@1.0.0");
+        assert_eq!(
+            spec.input,
+            json!({
+                "backup_path": "/tmp/configs",
+                "compress": true,
+            })
+        );
+    }
+
+    #[test]
+    fn task_spec_new_rejects_invalid_identity() {
+        let error = TaskSpec::new("acme.examples.backup_config", json!({}))
+            .expect_err("identity should be required");
+
+        assert_eq!(
+            error,
+            TaskSpecError::InvalidTaskIdentity {
+                identity: "acme.examples.backup_config".to_string(),
+                reason: "invalid task identity `acme.examples.backup_config`: identity must contain exactly one `@` separator".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn task_spec_deserializes_json_shape() {
+        let spec: TaskSpec = serde_json::from_value(json!({
+            "task": "acme.examples.backup_config@1.0.0",
+            "input": {
+                "backup_path": "/tmp/configs",
+                "compress": true,
+            }
+        }))
+        .expect("task spec should deserialize");
+
+        assert_eq!(spec.task, "acme.examples.backup_config@1.0.0");
+        assert_eq!(
+            spec.input,
+            json!({
+                "backup_path": "/tmp/configs",
+                "compress": true,
+            })
+        );
+    }
+
+    #[test]
+    fn task_spec_deserializes_missing_input_as_empty_object() {
+        let spec: TaskSpec = serde_json::from_value(json!({
+            "task": "acme.examples.collect_facts@1.0.0",
+        }))
+        .expect("task spec should deserialize");
+
+        assert_eq!(spec.input, json!({}));
+    }
+
+    #[test]
+    fn task_spec_rejects_unknown_fields() {
+        let error = serde_json::from_value::<TaskSpec>(json!({
+            "task": "acme.examples.backup_config@1.0.0",
+            "input": {},
+            "overrides": {},
+        }))
+        .expect_err("unknown fields should be rejected");
+
+        assert!(error.to_string().contains("unknown field `overrides`"));
+    }
+}

--- a/genja-core/src/task/spec.rs
+++ b/genja-core/src/task/spec.rs
@@ -5,7 +5,9 @@
 //! not run tasks, define task lists, apply execution overrides, or provide a
 //! workflow language.
 
-use super::TaskRegistrationKey;
+use super::{
+    TaskDefinition, TaskRegistrationError, TaskRegistrationKey, create_compiled_task_by_identity,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::error::Error;
@@ -86,6 +88,45 @@ impl fmt::Display for TaskSpecError {
 }
 
 impl Error for TaskSpecError {}
+
+/// Errors returned while constructing a compiled task from a declarative spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskSpecConstructionError {
+    /// The task spec could not be parsed or validated.
+    InvalidSpec(TaskSpecError),
+    /// The spec was valid, but compiled task lookup or construction failed.
+    Registration(TaskRegistrationError),
+}
+
+impl fmt::Display for TaskSpecConstructionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSpec(error) => write!(f, "{error}"),
+            Self::Registration(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl Error for TaskSpecConstructionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidSpec(error) => Some(error),
+            Self::Registration(error) => Some(error),
+        }
+    }
+}
+
+impl From<TaskSpecError> for TaskSpecConstructionError {
+    fn from(error: TaskSpecError) -> Self {
+        Self::InvalidSpec(error)
+    }
+}
+
+impl From<TaskRegistrationError> for TaskSpecConstructionError {
+    fn from(error: TaskRegistrationError) -> Self {
+        Self::Registration(error)
+    }
+}
 
 /// Declarative spec for constructing one registered task.
 ///
@@ -212,6 +253,32 @@ impl FromStr for TaskSpec {
     fn from_str(source: &str) -> Result<Self, Self::Err> {
         Self::parse_auto(source)
     }
+}
+
+/// Construct a compiled task from a validated declarative task spec.
+///
+/// This helper uses the compiled task registry and passes the spec's
+/// JSON-compatible `input` to the registered task factory selected by
+/// `spec.task`.
+pub fn create_compiled_task_from_spec(
+    spec: TaskSpec,
+) -> Result<TaskDefinition, TaskSpecConstructionError> {
+    create_compiled_task_by_identity(&spec.task, spec.input).map_err(Into::into)
+}
+
+/// Parse a task spec string with auto JSON/YAML parsing and construct its task.
+pub fn create_compiled_task_from_spec_str(
+    source: &str,
+) -> Result<TaskDefinition, TaskSpecConstructionError> {
+    create_compiled_task_from_spec(TaskSpec::parse_auto(source)?)
+}
+
+/// Parse a task spec string with an explicit format and construct its task.
+pub fn create_compiled_task_from_spec_str_with_format(
+    source: &str,
+    format: TaskSpecFormat,
+) -> Result<TaskDefinition, TaskSpecConstructionError> {
+    create_compiled_task_from_spec(TaskSpec::parse(source, format)?)
 }
 
 fn empty_input() -> Value {

--- a/genja-core/src/task/spec.rs
+++ b/genja-core/src/task/spec.rs
@@ -1,12 +1,13 @@
 //! Declarative task invocation specs.
 //!
 //! `TaskSpec` is the minimal data model for constructing one registered task
-//! from a stable task identity and JSON-compatible input. It intentionally does
-//! not run tasks, define task lists, apply execution overrides, or provide a
-//! workflow language.
+//! from a stable task identity and JSON-compatible input. It can also carry
+//! narrow per-run runtime policy overrides. It intentionally does not run tasks,
+//! define task lists, or provide a workflow language.
 
 use super::{
-    TaskDefinition, TaskRegistrationError, TaskRegistrationKey, create_compiled_task_by_identity,
+    RetryConfig, SessionVerificationConfig, TaskDefinition, TaskRegistrationError,
+    TaskRegistrationKey, create_compiled_task_by_identity,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -50,6 +51,13 @@ pub enum TaskSpecError {
         /// Human-readable shape failure.
         message: String,
     },
+    /// A task spec override is unsupported or invalid.
+    InvalidOverride {
+        /// Override field path.
+        field: String,
+        /// Human-readable validation failure.
+        message: String,
+    },
     /// The `task` identity failed `<task-id>@<task-version>` validation.
     InvalidTaskIdentity {
         /// Invalid identity value.
@@ -79,6 +87,9 @@ impl fmt::Display for TaskSpecError {
             }
             Self::InvalidShape { message } => {
                 write!(f, "invalid task spec: {message}")
+            }
+            Self::InvalidOverride { field, message } => {
+                write!(f, "invalid task spec override `{field}`: {message}")
             }
             Self::InvalidTaskIdentity { identity, reason } => {
                 write!(f, "invalid task spec identity `{identity}`: {reason}")
@@ -128,12 +139,46 @@ impl From<TaskRegistrationError> for TaskSpecConstructionError {
     }
 }
 
+/// Per-run runtime policy overrides for a declarative task spec.
+///
+/// Overrides are intentionally narrow. They can tune runtime policy for a
+/// single constructed task, but they do not rewrite authored task behavior,
+/// change processors, change connection plugins, or alter registration
+/// metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskSpecOverrides {
+    /// Optional retry policy override for this task construction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry: Option<RetryConfig>,
+    /// Optional post-change session verification override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_verification: Option<SessionVerificationConfig>,
+}
+
+impl TaskSpecOverrides {
+    /// Validate override values.
+    pub fn validate(&self) -> Result<(), TaskSpecError> {
+        if let Some(config) = self.session_verification
+            && config.max_attempts() == 0
+        {
+            return Err(TaskSpecError::InvalidOverride {
+                field: "overrides.session_verification.max_attempts".to_string(),
+                message: "must be greater than 0".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
 /// Declarative spec for constructing one registered task.
 ///
 /// `task` must be a rendered registration identity in
 /// `<task-id>@<task-version>` form. `input` is passed to the registered task
 /// factory as JSON-compatible construction input. When `input` is omitted, it
-/// defaults to an empty object.
+/// defaults to an empty object. `overrides` can tune narrow runtime policy for
+/// the constructed task without changing the authored task behavior.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaskSpec {
@@ -142,6 +187,9 @@ pub struct TaskSpec {
     /// JSON-compatible task construction input.
     #[serde(default = "empty_input")]
     pub input: Value,
+    /// Optional per-run runtime policy overrides.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overrides: Option<TaskSpecOverrides>,
 }
 
 impl TaskSpec {
@@ -150,6 +198,7 @@ impl TaskSpec {
         let spec = Self {
             task: task.into(),
             input,
+            overrides: None,
         };
         spec.validate()?;
         Ok(spec)
@@ -207,9 +256,12 @@ impl TaskSpec {
         let object = value.as_object().ok_or_else(expected_shape_error)?;
         if !object.contains_key("task") {
             return Err(TaskSpecError::InvalidShape {
-                message: "missing required field `task`; expected an object with `task` and optional `input`".to_string(),
+                message:
+                    "missing required field `task`; expected an object with `task`, optional `input`, and optional `overrides`"
+                        .to_string(),
             });
         }
+        validate_overrides_shape(object)?;
 
         let spec: Self =
             serde_json::from_value(value).map_err(|error| TaskSpecError::InvalidShape {
@@ -227,6 +279,9 @@ impl TaskSpec {
                 reason: error.to_string(),
             }
         })?;
+        if let Some(overrides) = &self.overrides {
+            overrides.validate()?;
+        }
         Ok(())
     }
 }
@@ -241,8 +296,32 @@ fn parse_yaml_value(source: &str) -> Result<Value, String> {
 
 fn expected_shape_error() -> TaskSpecError {
     TaskSpecError::InvalidShape {
-        message: "expected an object with `task` and optional `input`".to_string(),
+        message: "expected an object with `task`, optional `input`, and optional `overrides`"
+            .to_string(),
     }
+}
+
+fn validate_overrides_shape(object: &Map<String, Value>) -> Result<(), TaskSpecError> {
+    let Some(overrides) = object.get("overrides") else {
+        return Ok(());
+    };
+    let overrides = overrides
+        .as_object()
+        .ok_or_else(|| TaskSpecError::InvalidOverride {
+            field: "overrides".to_string(),
+            message: "expected an object".to_string(),
+        })?;
+
+    for key in overrides.keys() {
+        if key != "retry" && key != "session_verification" {
+            return Err(TaskSpecError::InvalidOverride {
+                field: format!("overrides.{key}"),
+                message: "unsupported override field".to_string(),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 impl FromStr for TaskSpec {
@@ -263,7 +342,8 @@ impl FromStr for TaskSpec {
 pub fn create_compiled_task_from_spec(
     spec: TaskSpec,
 ) -> Result<TaskDefinition, TaskSpecConstructionError> {
-    create_compiled_task_by_identity(&spec.task, spec.input).map_err(Into::into)
+    let task = create_compiled_task_by_identity(&spec.task, spec.input)?;
+    Ok(apply_overrides(task, spec.overrides))
 }
 
 /// Parse a task spec string with auto JSON/YAML parsing and construct its task.
@@ -283,6 +363,22 @@ pub fn create_compiled_task_from_spec_str_with_format(
 
 fn empty_input() -> Value {
     Value::Object(Map::new())
+}
+
+fn apply_overrides(task: TaskDefinition, overrides: Option<TaskSpecOverrides>) -> TaskDefinition {
+    let Some(overrides) = overrides else {
+        return task;
+    };
+    let task = if let Some(retry) = overrides.retry {
+        task.with_retry_config_override(retry)
+    } else {
+        task
+    };
+    if let Some(session_verification) = overrides.session_verification {
+        task.with_session_verification_config_override(session_verification)
+    } else {
+        task
+    }
 }
 
 #[cfg(test)]
@@ -489,7 +585,9 @@ input:
         assert_eq!(
             error,
             TaskSpecError::InvalidShape {
-                message: "expected an object with `task` and optional `input`".to_string(),
+                message:
+                    "expected an object with `task`, optional `input`, and optional `overrides`"
+                        .to_string(),
             }
         );
     }
@@ -502,7 +600,82 @@ input:
         assert_eq!(
             error,
             TaskSpecError::InvalidShape {
-                message: "missing required field `task`; expected an object with `task` and optional `input`".to_string(),
+                message:
+                    "missing required field `task`; expected an object with `task`, optional `input`, and optional `overrides`"
+                        .to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn task_spec_parses_retry_and_session_verification_overrides() {
+        let spec = TaskSpec::from_yaml_str(
+            r#"
+task: acme.examples.backup_config@1.0.0
+input:
+  backup_path: /tmp/configs
+overrides:
+  retry:
+    allow: true
+    max_attempts: 4
+    delay_ms: 250
+  session_verification:
+    max_attempts: 2
+    delay_ms: 1000
+"#,
+        )
+        .expect("task spec overrides should parse");
+
+        let overrides = spec.overrides.expect("overrides should be present");
+        let retry = overrides.retry.expect("retry override should be present");
+        assert_eq!(retry.allow(), Some(true));
+        assert_eq!(retry.max_attempts(), Some(4));
+        assert_eq!(retry.delay_ms(), Some(250));
+        let session_verification = overrides
+            .session_verification
+            .expect("session verification override should be present");
+        assert_eq!(session_verification.max_attempts(), 2);
+        assert_eq!(session_verification.delay_ms(), 1000);
+    }
+
+    #[test]
+    fn task_spec_rejects_unsupported_processor_override() {
+        let error = TaskSpec::from_yaml_str(
+            r#"
+task: acme.examples.backup_config@1.0.0
+overrides:
+  processors: ["audit"]
+"#,
+        )
+        .expect_err("processor override should be unsupported");
+
+        assert_eq!(
+            error,
+            TaskSpecError::InvalidOverride {
+                field: "overrides.processors".to_string(),
+                message: "unsupported override field".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn task_spec_rejects_invalid_session_verification_override() {
+        let error = TaskSpec::from_yaml_str(
+            r#"
+task: acme.examples.backup_config@1.0.0
+overrides:
+  session_verification:
+    max_attempts: 0
+    delay_ms: 1000
+"#,
+        )
+        .expect_err("invalid session verification override should be rejected");
+
+        assert_eq!(
+            error,
+            TaskSpecError::InvalidOverride {
+                field: "overrides.session_verification.max_attempts".to_string(),
+                message: "must be greater than 0".to_string(),
             }
         );
     }
@@ -531,6 +704,8 @@ input:
 
         assert_eq!(yaml.input, json!({}));
         assert_eq!(json.input, json!({}));
+        assert_eq!(yaml.overrides, None);
+        assert_eq!(json.overrides, None);
     }
 
     #[test]
@@ -582,10 +757,10 @@ input:
         let error = serde_json::from_value::<TaskSpec>(json!({
             "task": "acme.examples.backup_config@1.0.0",
             "input": {},
-            "overrides": {},
+            "metadata": {},
         }))
         .expect_err("unknown fields should be rejected");
 
-        assert!(error.to_string().contains("unknown field `overrides`"));
+        assert!(error.to_string().contains("unknown field `metadata`"));
     }
 }

--- a/genja-core/src/task/spec.rs
+++ b/genja-core/src/task/spec.rs
@@ -10,10 +10,44 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::error::Error;
 use std::fmt;
+use std::str::FromStr;
+
+/// Text format used when parsing a declarative task spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskSpecFormat {
+    /// Try JSON first, then YAML.
+    Auto,
+    /// Parse the source text as JSON.
+    Json,
+    /// Parse the source text as YAML.
+    Yaml,
+}
 
 /// Errors returned while validating declarative task specs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskSpecError {
+    /// Automatic task spec parsing failed for every supported text format.
+    InvalidAuto {
+        /// Human-readable JSON parse failure.
+        json_message: String,
+        /// Human-readable YAML parse failure.
+        yaml_message: String,
+    },
+    /// YAML task spec parsing failed.
+    InvalidYaml {
+        /// Human-readable parse failure.
+        message: String,
+    },
+    /// JSON task spec parsing failed.
+    InvalidJson {
+        /// Human-readable parse failure.
+        message: String,
+    },
+    /// The source parsed successfully but does not have the task spec shape.
+    InvalidShape {
+        /// Human-readable shape failure.
+        message: String,
+    },
     /// The `task` identity failed `<task-id>@<task-version>` validation.
     InvalidTaskIdentity {
         /// Invalid identity value.
@@ -26,6 +60,24 @@ pub enum TaskSpecError {
 impl fmt::Display for TaskSpecError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InvalidAuto {
+                json_message,
+                yaml_message,
+            } => {
+                write!(
+                    f,
+                    "could not parse task spec as JSON or YAML; JSON parser reported: {json_message}; YAML parser reported: {yaml_message}"
+                )
+            }
+            Self::InvalidYaml { message } => {
+                write!(f, "invalid YAML task spec: {message}")
+            }
+            Self::InvalidJson { message } => {
+                write!(f, "invalid JSON task spec: {message}")
+            }
+            Self::InvalidShape { message } => {
+                write!(f, "invalid task spec: {message}")
+            }
             Self::InvalidTaskIdentity { identity, reason } => {
                 write!(f, "invalid task spec identity `{identity}`: {reason}")
             }
@@ -62,6 +114,70 @@ impl TaskSpec {
         Ok(spec)
     }
 
+    /// Parse a single-task spec from text using an explicit format.
+    pub fn parse(source: &str, format: TaskSpecFormat) -> Result<Self, TaskSpecError> {
+        match format {
+            TaskSpecFormat::Auto => Self::parse_auto(source),
+            TaskSpecFormat::Json => Self::from_json_str(source),
+            TaskSpecFormat::Yaml => Self::from_yaml_str(source),
+        }
+    }
+
+    /// Parse a single-task spec from text as JSON or YAML.
+    ///
+    /// JSON is tried first. If it fails to parse, YAML is tried. If neither
+    /// format parses, the error reports both parser failures. If either format
+    /// parses but the document is not a task spec object, a format-neutral
+    /// shape error is returned.
+    pub fn parse_auto(source: &str) -> Result<Self, TaskSpecError> {
+        match parse_json_value(source) {
+            Ok(value) => Self::from_value(value),
+            Err(json_message) => match parse_yaml_value(source) {
+                Ok(value) => Self::from_value(value),
+                Err(yaml_message) => Err(TaskSpecError::InvalidAuto {
+                    json_message,
+                    yaml_message,
+                }),
+            },
+        }
+    }
+
+    /// Parse a single-task spec from YAML text.
+    ///
+    /// Use [`TaskSpec::parse_auto`] for a parser that accepts the common JSON
+    /// and YAML file shapes through one entry point.
+    pub fn from_yaml_str(source: &str) -> Result<Self, TaskSpecError> {
+        let value =
+            parse_yaml_value(source).map_err(|message| TaskSpecError::InvalidYaml { message })?;
+        Self::from_value(value)
+    }
+
+    /// Parse a single-task spec from JSON text.
+    ///
+    /// Use [`TaskSpec::parse_auto`] for a parser that accepts the common JSON
+    /// and YAML file shapes through one entry point.
+    pub fn from_json_str(source: &str) -> Result<Self, TaskSpecError> {
+        let value =
+            parse_json_value(source).map_err(|message| TaskSpecError::InvalidJson { message })?;
+        Self::from_value(value)
+    }
+
+    fn from_value(value: Value) -> Result<Self, TaskSpecError> {
+        let object = value.as_object().ok_or_else(expected_shape_error)?;
+        if !object.contains_key("task") {
+            return Err(TaskSpecError::InvalidShape {
+                message: "missing required field `task`; expected an object with `task` and optional `input`".to_string(),
+            });
+        }
+
+        let spec: Self =
+            serde_json::from_value(value).map_err(|error| TaskSpecError::InvalidShape {
+                message: error.to_string(),
+            })?;
+        spec.validate()?;
+        Ok(spec)
+    }
+
     /// Validate this spec's task identity.
     pub fn validate(&self) -> Result<(), TaskSpecError> {
         TaskRegistrationKey::parse(&self.task).map_err(|error| {
@@ -71,6 +187,30 @@ impl TaskSpec {
             }
         })?;
         Ok(())
+    }
+}
+
+fn parse_json_value(source: &str) -> Result<Value, String> {
+    serde_json::from_str(source).map_err(|error| error.to_string())
+}
+
+fn parse_yaml_value(source: &str) -> Result<Value, String> {
+    serde_yaml::from_str(source).map_err(|error| error.to_string())
+}
+
+fn expected_shape_error() -> TaskSpecError {
+    TaskSpecError::InvalidShape {
+        message: "expected an object with `task` and optional `input`".to_string(),
+    }
+}
+
+impl FromStr for TaskSpec {
+    type Err = TaskSpecError;
+
+    /// Parse a task spec with the same deterministic format detection as
+    /// [`TaskSpec::parse_auto`].
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        Self::parse_auto(source)
     }
 }
 
@@ -147,6 +287,227 @@ mod tests {
         .expect("task spec should deserialize");
 
         assert_eq!(spec.input, json!({}));
+    }
+
+    #[test]
+    fn task_spec_parses_yaml_source() {
+        let spec = TaskSpec::from_yaml_str(
+            r#"
+task: acme.examples.backup_config@1.0.0
+input:
+  backup_path: /tmp/configs
+  compress: true
+  rules:
+    - path: /etc/network
+      recursive: true
+"#,
+        )
+        .expect("YAML task spec should parse");
+
+        assert_eq!(spec.task, "acme.examples.backup_config@1.0.0");
+        assert_eq!(
+            spec.input,
+            json!({
+                "backup_path": "/tmp/configs",
+                "compress": true,
+                "rules": [
+                    {
+                        "path": "/etc/network",
+                        "recursive": true,
+                    }
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn task_spec_parses_json_source() {
+        let spec = TaskSpec::from_json_str(
+            r#"
+{
+  "task": "acme.examples.backup_config@1.0.0",
+  "input": {
+    "backup_path": "/tmp/configs",
+    "compress": true
+  }
+}
+"#,
+        )
+        .expect("JSON task spec should parse");
+
+        assert_eq!(spec.task, "acme.examples.backup_config@1.0.0");
+        assert_eq!(
+            spec.input,
+            json!({
+                "backup_path": "/tmp/configs",
+                "compress": true,
+            })
+        );
+    }
+
+    #[test]
+    fn task_spec_parse_uses_explicit_format() {
+        let auto = TaskSpec::parse(
+            "task: acme.examples.collect_facts@1.0.0\n",
+            TaskSpecFormat::Auto,
+        )
+        .expect("auto task spec should parse");
+        let yaml = TaskSpec::parse(
+            "task: acme.examples.collect_facts@1.0.0\n",
+            TaskSpecFormat::Yaml,
+        )
+        .expect("YAML task spec should parse");
+        let json = TaskSpec::parse(
+            r#"{ "task": "acme.examples.collect_facts@1.0.0" }"#,
+            TaskSpecFormat::Json,
+        )
+        .expect("JSON task spec should parse");
+
+        assert_eq!(auto.task, "acme.examples.collect_facts@1.0.0");
+        assert_eq!(yaml.task, "acme.examples.collect_facts@1.0.0");
+        assert_eq!(json.task, "acme.examples.collect_facts@1.0.0");
+    }
+
+    #[test]
+    fn task_spec_parse_auto_accepts_yaml_and_json() {
+        let yaml = TaskSpec::parse_auto("task: acme.examples.collect_facts@1.0.0\n")
+            .expect("YAML task spec should parse");
+        let json = TaskSpec::parse_auto(
+            r#"
+{
+  "task": "acme.examples.backup_config@1.0.0",
+  "input": {
+    "backup_path": "/tmp/configs"
+  }
+}
+"#,
+        )
+        .expect("JSON task spec should parse");
+
+        assert_eq!(yaml.task, "acme.examples.collect_facts@1.0.0");
+        assert_eq!(json.task, "acme.examples.backup_config@1.0.0");
+        assert_eq!(
+            json.input,
+            json!({
+                "backup_path": "/tmp/configs",
+            })
+        );
+    }
+
+    #[test]
+    fn task_spec_parse_auto_rejects_text_that_is_neither_json_nor_yaml() {
+        let error = TaskSpec::parse_auto(
+            r#"
+## Starting
+
+* bullets garbage
+* points dnd
+"#,
+        )
+        .expect_err("Markdown-like text should not parse as a task spec");
+
+        assert!(matches!(error, TaskSpecError::InvalidAuto { .. }));
+        assert!(
+            error
+                .to_string()
+                .starts_with("could not parse task spec as JSON or YAML;")
+        );
+    }
+
+    #[test]
+    fn task_spec_parse_auto_rejects_parsed_scalar_with_shape_error() {
+        let error = TaskSpec::parse_auto("\"I am a string, not a task spec.\"")
+            .expect_err("scalar text should not be a task spec");
+
+        assert_eq!(
+            error,
+            TaskSpecError::InvalidShape {
+                message: "expected an object with `task` and optional `input`".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn task_spec_parse_auto_rejects_object_without_task_with_shape_error() {
+        let error = TaskSpec::parse_auto("input:\n  name: router1\n")
+            .expect_err("task field should be required");
+
+        assert_eq!(
+            error,
+            TaskSpecError::InvalidShape {
+                message: "missing required field `task`; expected an object with `task` and optional `input`".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn task_spec_from_str_uses_auto_detection() {
+        let spec = "task: acme.examples.collect_facts@1.0.0\n"
+            .parse::<TaskSpec>()
+            .expect("YAML task spec should parse");
+
+        assert_eq!(spec.task, "acme.examples.collect_facts@1.0.0");
+    }
+
+    #[test]
+    fn task_spec_parsers_default_missing_input_to_empty_object() {
+        let yaml = TaskSpec::from_yaml_str("task: acme.examples.collect_facts@1.0.0\n")
+            .expect("YAML task spec should parse");
+        let json = TaskSpec::from_json_str(
+            r#"
+{
+  "task": "acme.examples.collect_facts@1.0.0"
+}
+"#,
+        )
+        .expect("JSON task spec should parse");
+
+        assert_eq!(yaml.input, json!({}));
+        assert_eq!(json.input, json!({}));
+    }
+
+    #[test]
+    fn task_spec_from_yaml_str_rejects_malformed_yaml() {
+        let error = TaskSpec::from_yaml_str("task: [").expect_err("YAML should be invalid");
+
+        assert!(matches!(error, TaskSpecError::InvalidYaml { .. }));
+        assert!(error.to_string().starts_with("invalid YAML task spec:"));
+    }
+
+    #[test]
+    fn task_spec_from_json_str_rejects_malformed_json() {
+        let error = TaskSpec::from_json_str(r#"{ "task": "#).expect_err("JSON should be invalid");
+
+        assert!(matches!(error, TaskSpecError::InvalidJson { .. }));
+        assert!(error.to_string().starts_with("invalid JSON task spec:"));
+    }
+
+    #[test]
+    fn explicit_parsers_reject_parsed_scalar_with_shape_error() {
+        let yaml_error =
+            TaskSpec::from_yaml_str("plain text").expect_err("YAML scalar should not be a spec");
+        let json_error = TaskSpec::from_json_str("\"plain text\"")
+            .expect_err("JSON scalar should not be a spec");
+
+        assert!(matches!(yaml_error, TaskSpecError::InvalidShape { .. }));
+        assert!(matches!(json_error, TaskSpecError::InvalidShape { .. }));
+    }
+
+    #[test]
+    fn task_spec_parsers_validate_identity_after_parse() {
+        let yaml_error = TaskSpec::from_yaml_str("task: acme.examples.backup_config\n")
+            .expect_err("identity should be invalid");
+        let json_error = TaskSpec::from_json_str(r#"{ "task": "acme.examples.backup_config" }"#)
+            .expect_err("identity should be invalid");
+
+        assert!(matches!(
+            yaml_error,
+            TaskSpecError::InvalidTaskIdentity { .. }
+        ));
+        assert!(matches!(
+            json_error,
+            TaskSpecError::InvalidTaskIdentity { .. }
+        ));
     }
 
     #[test]

--- a/genja-core/tests/compiled_registration_duplicates.rs
+++ b/genja-core/tests/compiled_registration_duplicates.rs
@@ -1,0 +1,59 @@
+use genja_core::genja_task;
+use genja_core::inventory::Host;
+use genja_core::task::{
+    HostTaskResult, TaskRegistrationError, TaskRuntimeContext, TaskSuccess, compiled_task_registry,
+};
+
+#[derive(serde::Deserialize)]
+struct FirstDuplicateTask;
+
+#[genja_task(
+    name = "first_duplicate_task",
+    registration(id = "acme.tests.compiled_duplicates.same_task", version = "1.0.0")
+)]
+impl FirstDuplicateTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct SecondDuplicateTask;
+
+#[genja_task(
+    name = "second_duplicate_task",
+    registration(id = "acme.tests.compiled_duplicates.same_task", version = "1.0.0")
+)]
+impl SecondDuplicateTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+}
+
+#[test]
+fn compiled_registry_rejects_duplicate_macro_registrations() {
+    let error = match compiled_task_registry() {
+        Ok(_) => panic!("duplicate registrations should fail"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        TaskRegistrationError::DuplicateRegistration {
+            id: "acme.tests.compiled_duplicates.same_task".to_string(),
+            version: "1.0.0".to_string(),
+        }
+    );
+    assert_eq!(
+        error.to_string(),
+        "duplicate task registration `acme.tests.compiled_duplicates.same_task@1.0.0`"
+    );
+}

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -4,7 +4,8 @@ use genja_core::genja_task;
 use genja_core::inventory::{BaseBuilderHost, Host};
 use genja_core::task::{
     BlockingTaskRuntimeContext, HostTaskResult, IdempotencyCheck, IdempotencyMode, Task,
-    TaskExecutionMode, TaskInfo, TaskRuntimeContext, TaskSuccess,
+    TaskCatalog, TaskExecutionMode, TaskIdSource, TaskInfo, TaskRuntimeContext, TaskSuccess,
+    compiled_task_registry, get_compiled_task_descriptor,
 };
 use serde_json::{Value, json};
 
@@ -194,6 +195,49 @@ fn genja_task_generates_task_info_from_metadata() {
     assert!(task.helper());
     assert!(!task.supports_dry_run());
     assert_eq!(task.idempotency_mode(), IdempotencyMode::Disabled);
+}
+
+#[test]
+fn genja_task_submits_generated_discovery_descriptor() {
+    let task_id = format!("auto:{}", std::any::type_name::<AsyncTask>());
+    let descriptor = get_compiled_task_descriptor(&task_id, Some(env!("CARGO_PKG_VERSION")))
+        .expect("generated descriptor should be registered");
+
+    assert_eq!(descriptor.id, task_id);
+    assert_eq!(descriptor.id_source, TaskIdSource::Generated);
+    assert_eq!(descriptor.name, "async_task");
+    assert_eq!(descriptor.version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(descriptor.description, None);
+    assert_eq!(descriptor.execution_mode, TaskExecutionMode::Async);
+    assert_eq!(descriptor.connection_plugin_name.as_deref(), Some("ssh"));
+    assert_eq!(descriptor.processor_names, vec!["audit", "metrics"]);
+    assert_eq!(descriptor.input_schema, None);
+    assert!(!descriptor.constructible);
+
+    let retry_config = descriptor
+        .retry
+        .expect("retry metadata should be included in descriptor");
+    assert_eq!(retry_config.allow(), Some(true));
+    assert_eq!(retry_config.max_attempts(), Some(3));
+    assert_eq!(retry_config.delay_ms(), Some(500));
+}
+
+#[test]
+fn genja_task_compiled_registry_lists_generated_descriptors_deterministically() {
+    let registry = compiled_task_registry().expect("compiled registry should build");
+    let descriptors = registry.list().expect("compiled descriptors should list");
+    let task_id = format!("auto:{}", std::any::type_name::<BlockingTask>());
+
+    assert!(descriptors.windows(2).all(|window| {
+        (&window[0].id, &window[0].version) <= (&window[1].id, &window[1].version)
+    }));
+    assert!(descriptors.iter().any(|descriptor| {
+        descriptor.id == task_id
+            && descriptor.version == env!("CARGO_PKG_VERSION")
+            && descriptor.id_source == TaskIdSource::Generated
+            && descriptor.execution_mode == TaskExecutionMode::Blocking
+            && !descriptor.constructible
+    }));
 }
 
 #[test]

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -6,6 +6,7 @@ use genja_core::task::{
     BlockingTaskRuntimeContext, HostTaskResult, IdempotencyCheck, IdempotencyMode, Task,
     TaskCatalog, TaskExecutionMode, TaskFactoryRegistry, TaskIdSource, TaskInfo,
     TaskRuntimeContext, TaskSuccess, compiled_task_registry, create_compiled_task_by_identity,
+    create_compiled_task_from_spec_str, create_compiled_task_from_spec_str_with_format,
     get_compiled_task_descriptor, get_compiled_task_descriptor_by_identity,
 };
 use serde_json::{Value, json};
@@ -424,6 +425,81 @@ fn genja_task_compiled_registry_supports_identity_task_creation() {
 
     assert_eq!(task.name(), "registered_serde_task");
     assert_eq!(task.options(), Some(&json!({ "source": "identity" })));
+}
+
+#[test]
+fn genja_task_compiled_registry_creates_task_from_yaml_spec() {
+    let task = create_compiled_task_from_spec_str(
+        r#"
+task: acme.tests.derive_runtime.registered_serde_task@1.2.3
+input:
+  options:
+    source: yaml-spec
+"#,
+    )
+    .expect("YAML task spec should construct task");
+
+    assert_eq!(task.name(), "registered_serde_task");
+    assert_eq!(task.options(), Some(&json!({ "source": "yaml-spec" })));
+}
+
+#[test]
+fn genja_task_compiled_registry_creates_task_from_json_spec() {
+    let task = create_compiled_task_from_spec_str_with_format(
+        r#"
+{
+  "task": "acme.tests.derive_runtime.registered_serde_task@1.2.3",
+  "input": {
+    "options": {
+      "source": "json-spec"
+    }
+  }
+}
+"#,
+        genja_core::task::TaskSpecFormat::Json,
+    )
+    .expect("JSON task spec should construct task");
+
+    assert_eq!(task.name(), "registered_serde_task");
+    assert_eq!(task.options(), Some(&json!({ "source": "json-spec" })));
+}
+
+#[test]
+fn genja_task_compiled_registry_preserves_spec_parse_errors() {
+    let error = create_compiled_task_from_spec_str(
+        r#"
+## Starting
+
+* bullets garbage
+* points dnd
+"#,
+    )
+    .expect_err("invalid spec text should be rejected");
+
+    assert!(matches!(
+        error,
+        genja_core::task::TaskSpecConstructionError::InvalidSpec(
+            genja_core::task::TaskSpecError::InvalidAuto { .. }
+        )
+    ));
+}
+
+#[test]
+fn genja_task_compiled_registry_preserves_unknown_task_errors_from_spec() {
+    let error = create_compiled_task_from_spec_str(
+        r#"
+task: acme.tests.derive_runtime.missing_task@1.0.0
+input: {}
+"#,
+    )
+    .expect_err("unknown task should be rejected by registry");
+
+    assert!(matches!(
+        error,
+        genja_core::task::TaskSpecConstructionError::Registration(
+            genja_core::task::TaskRegistrationError::NotFound { .. }
+        )
+    ));
 }
 
 #[test]

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -4,8 +4,8 @@ use genja_core::genja_task;
 use genja_core::inventory::{BaseBuilderHost, Host};
 use genja_core::task::{
     BlockingTaskRuntimeContext, HostTaskResult, IdempotencyCheck, IdempotencyMode, Task,
-    TaskCatalog, TaskExecutionMode, TaskIdSource, TaskInfo, TaskRuntimeContext, TaskSuccess,
-    compiled_task_registry, get_compiled_task_descriptor,
+    TaskCatalog, TaskExecutionMode, TaskFactoryRegistry, TaskIdSource, TaskInfo,
+    TaskRuntimeContext, TaskSuccess, compiled_task_registry, get_compiled_task_descriptor,
 };
 use serde_json::{Value, json};
 
@@ -171,6 +171,51 @@ impl BlockingDryRunTask {
     }
 }
 
+#[derive(serde::Deserialize)]
+struct RegisteredSerdeTask {
+    options: Value,
+}
+
+#[genja_task(
+    name = "registered_serde_task",
+    processors = ["audit"],
+    registration(
+        id = "acme.tests.derive_runtime.registered_serde_task",
+        version = "1.2.3",
+        description = "Constructs a task from JSON input"
+    )
+)]
+impl RegisteredSerdeTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+
+    fn options(&self) -> Option<&Value> {
+        Some(&self.options)
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct RegisteredDefaultVersionTask;
+
+#[genja_task(
+    name = "registered_default_version_task",
+    registration(id = "acme.tests.derive_runtime.registered_default_version_task")
+)]
+impl RegisteredDefaultVersionTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+}
+
 #[test]
 fn genja_task_generates_task_info_from_metadata() {
     let task = AsyncTask {
@@ -195,6 +240,72 @@ fn genja_task_generates_task_info_from_metadata() {
     assert!(task.helper());
     assert!(!task.supports_dry_run());
     assert_eq!(task.idempotency_mode(), IdempotencyMode::Disabled);
+}
+
+#[test]
+fn genja_task_submits_explicit_constructible_registration() {
+    let descriptor = get_compiled_task_descriptor(
+        "acme.tests.derive_runtime.registered_serde_task",
+        Some("1.2.3"),
+    )
+    .expect("explicit descriptor should be registered");
+
+    assert_eq!(
+        descriptor.id,
+        "acme.tests.derive_runtime.registered_serde_task"
+    );
+    assert_eq!(descriptor.id_source, TaskIdSource::Explicit);
+    assert_eq!(descriptor.name, "registered_serde_task");
+    assert_eq!(descriptor.version, "1.2.3");
+    assert_eq!(
+        descriptor.description.as_deref(),
+        Some("Constructs a task from JSON input")
+    );
+    assert_eq!(descriptor.execution_mode, TaskExecutionMode::Async);
+    assert_eq!(descriptor.processor_names, vec!["audit"]);
+    assert_eq!(descriptor.input_schema, None);
+    assert!(descriptor.constructible);
+}
+
+#[test]
+fn genja_task_compiled_registry_creates_registered_task_from_json() {
+    let registry = compiled_task_registry().expect("compiled registry should build");
+    let task = registry
+        .create(
+            "acme.tests.derive_runtime.registered_serde_task",
+            Some("1.2.3"),
+            json!({ "options": { "source": "json" } }),
+        )
+        .expect("registered serde factory should create task");
+
+    assert_eq!(task.name(), "registered_serde_task");
+    assert_eq!(task.options(), Some(&json!({ "source": "json" })));
+
+    let error = match registry.create(
+        "acme.tests.derive_runtime.registered_serde_task",
+        Some("1.2.3"),
+        json!({ "unexpected": true }),
+    ) {
+        Ok(_) => panic!("serde factory should reject invalid input"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        genja_core::task::TaskRegistrationError::InvalidInput { .. }
+    ));
+}
+
+#[test]
+fn genja_task_registration_version_defaults_to_package_version() {
+    let descriptor = get_compiled_task_descriptor(
+        "acme.tests.derive_runtime.registered_default_version_task",
+        Some(env!("CARGO_PKG_VERSION")),
+    )
+    .expect("explicit descriptor should be registered with package version");
+
+    assert_eq!(descriptor.id_source, TaskIdSource::Explicit);
+    assert_eq!(descriptor.version, env!("CARGO_PKG_VERSION"));
+    assert!(descriptor.constructible);
 }
 
 #[test]

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -216,6 +216,71 @@ impl RegisteredDefaultVersionTask {
     }
 }
 
+#[derive(Default)]
+struct RegisteredDefaultFactoryTask;
+
+#[genja_task(
+    name = "registered_default_factory_task",
+    registration(
+        id = "acme.tests.derive_runtime.registered_default_factory_task",
+        factory = "default"
+    )
+)]
+impl RegisteredDefaultFactoryTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+}
+
+struct RegisteredCustomFactoryTask {
+    options: Value,
+}
+
+fn create_registered_custom_factory_task(
+    input: Value,
+) -> Result<RegisteredCustomFactoryTask, genja_core::task::TaskRegistrationError> {
+    let encoded = input
+        .get("encoded")
+        .and_then(Value::as_str)
+        .ok_or_else(|| genja_core::task::TaskRegistrationError::InvalidInput {
+            id: "acme.tests.derive_runtime.registered_custom_factory_task".to_string(),
+            version: "2.1.0".to_string(),
+            message: "`encoded` is required".to_string(),
+        })?;
+    let decoded: String = encoded.chars().rev().collect();
+
+    Ok(RegisteredCustomFactoryTask {
+        options: json!({ "decoded": decoded }),
+    })
+}
+
+#[genja_task(
+    name = "registered_custom_factory_task",
+    registration(
+        id = "acme.tests.derive_runtime.registered_custom_factory_task",
+        version = "2.1.0",
+        description = "Prepares obfuscated input before constructing the task",
+        factory = custom(create_registered_custom_factory_task)
+    )
+)]
+impl RegisteredCustomFactoryTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+
+    fn options(&self) -> Option<&Value> {
+        Some(&self.options)
+    }
+}
+
 #[test]
 fn genja_task_generates_task_info_from_metadata() {
     let task = AsyncTask {
@@ -306,6 +371,61 @@ fn genja_task_registration_version_defaults_to_package_version() {
     assert_eq!(descriptor.id_source, TaskIdSource::Explicit);
     assert_eq!(descriptor.version, env!("CARGO_PKG_VERSION"));
     assert!(descriptor.constructible);
+}
+
+#[test]
+fn genja_task_compiled_registry_creates_default_factory_task_from_empty_input() {
+    let registry = compiled_task_registry().expect("compiled registry should build");
+    let task = registry
+        .create(
+            "acme.tests.derive_runtime.registered_default_factory_task",
+            Some(env!("CARGO_PKG_VERSION")),
+            json!({}),
+        )
+        .expect("registered default factory should create task from empty object");
+
+    assert_eq!(task.name(), "registered_default_factory_task");
+
+    let error = match registry.create(
+        "acme.tests.derive_runtime.registered_default_factory_task",
+        Some(env!("CARGO_PKG_VERSION")),
+        json!({ "unexpected": true }),
+    ) {
+        Ok(_) => panic!("default factory should reject non-empty input"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        genja_core::task::TaskRegistrationError::InvalidInput { .. }
+    ));
+}
+
+#[test]
+fn genja_task_compiled_registry_creates_custom_factory_task_from_prepared_input() {
+    let registry = compiled_task_registry().expect("compiled registry should build");
+    let task = registry
+        .create(
+            "acme.tests.derive_runtime.registered_custom_factory_task",
+            Some("2.1.0"),
+            json!({ "encoded": "terces" }),
+        )
+        .expect("registered custom factory should create task");
+
+    assert_eq!(task.name(), "registered_custom_factory_task");
+    assert_eq!(task.options(), Some(&json!({ "decoded": "secret" })));
+
+    let error = match registry.create(
+        "acme.tests.derive_runtime.registered_custom_factory_task",
+        Some("2.1.0"),
+        json!({}),
+    ) {
+        Ok(_) => panic!("custom factory should reject invalid input"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        genja_core::task::TaskRegistrationError::InvalidInput { .. }
+    ));
 }
 
 #[test]

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -281,6 +281,44 @@ impl RegisteredCustomFactoryTask {
     }
 }
 
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct RegisteredSchemaTask {
+    acl_name: String,
+    rules: Vec<RegisteredSchemaRule>,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct RegisteredSchemaRule {
+    action: String,
+    cidr: String,
+}
+
+#[genja_task(
+    name = "registered_schema_task",
+    registration(
+        id = "acme.tests.derive_runtime.registered_schema_task",
+        version = "3.0.0",
+        description = "Exposes a JSON Schema for task input",
+        schema = "schemars"
+    )
+)]
+impl RegisteredSchemaTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        let first_rule = self
+            .rules
+            .first()
+            .map(|rule| format!("{}:{}", rule.action, rule.cidr))
+            .unwrap_or_else(|| "none".to_string());
+        Ok(HostTaskResult::passed(TaskSuccess::new().with_summary(
+            format!("{}:{}:{}", self.acl_name, self.rules.len(), first_rule),
+        )))
+    }
+}
+
 #[test]
 fn genja_task_generates_task_info_from_metadata() {
     let task = AsyncTask {
@@ -371,6 +409,30 @@ fn genja_task_registration_version_defaults_to_package_version() {
     assert_eq!(descriptor.id_source, TaskIdSource::Explicit);
     assert_eq!(descriptor.version, env!("CARGO_PKG_VERSION"));
     assert!(descriptor.constructible);
+}
+
+#[test]
+fn genja_task_submits_input_schema_when_registration_opts_in() {
+    let descriptor = get_compiled_task_descriptor(
+        "acme.tests.derive_runtime.registered_schema_task",
+        Some("3.0.0"),
+    )
+    .expect("explicit descriptor should be registered");
+    let schema = descriptor
+        .input_schema
+        .expect("schemars input schema should be included");
+
+    assert!(descriptor.constructible);
+    assert_eq!(schema["title"], "RegisteredSchemaTask");
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["required"], json!(["acl_name", "rules"]));
+    assert_eq!(schema["properties"]["acl_name"]["type"], "string");
+    assert_eq!(schema["properties"]["rules"]["type"], "array");
+    assert!(
+        schema["properties"]["rules"]["items"]["$ref"]
+            .as_str()
+            .is_some_and(|reference| reference.contains("RegisteredSchemaRule"))
+    );
 }
 
 #[test]

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -5,7 +5,8 @@ use genja_core::inventory::{BaseBuilderHost, Host};
 use genja_core::task::{
     BlockingTaskRuntimeContext, HostTaskResult, IdempotencyCheck, IdempotencyMode, Task,
     TaskCatalog, TaskExecutionMode, TaskFactoryRegistry, TaskIdSource, TaskInfo,
-    TaskRuntimeContext, TaskSuccess, compiled_task_registry, get_compiled_task_descriptor,
+    TaskRuntimeContext, TaskSuccess, compiled_task_registry, create_compiled_task_by_identity,
+    get_compiled_task_descriptor, get_compiled_task_descriptor_by_identity,
 };
 use serde_json::{Value, json};
 
@@ -396,6 +397,60 @@ fn genja_task_compiled_registry_creates_registered_task_from_json() {
         error,
         genja_core::task::TaskRegistrationError::InvalidInput { .. }
     ));
+}
+
+#[test]
+fn genja_task_compiled_registry_supports_identity_descriptor_lookup() {
+    let descriptor = get_compiled_task_descriptor_by_identity(
+        "acme.tests.derive_runtime.registered_serde_task@1.2.3",
+    )
+    .expect("identity descriptor lookup should succeed");
+
+    assert_eq!(
+        descriptor.id,
+        "acme.tests.derive_runtime.registered_serde_task"
+    );
+    assert_eq!(descriptor.version, "1.2.3");
+    assert!(descriptor.constructible);
+}
+
+#[test]
+fn genja_task_compiled_registry_supports_identity_task_creation() {
+    let task = create_compiled_task_by_identity(
+        "acme.tests.derive_runtime.registered_serde_task@1.2.3",
+        json!({ "options": { "source": "identity" } }),
+    )
+    .expect("identity create should succeed");
+
+    assert_eq!(task.name(), "registered_serde_task");
+    assert_eq!(task.options(), Some(&json!({ "source": "identity" })));
+}
+
+#[test]
+fn genja_task_compiled_descriptor_serializes_to_json_contract() {
+    let descriptor = get_compiled_task_descriptor(
+        "acme.tests.derive_runtime.registered_serde_task",
+        Some("1.2.3"),
+    )
+    .expect("explicit descriptor should be registered");
+    let serialized = serde_json::to_value(&descriptor).expect("descriptor should serialize");
+
+    assert_eq!(
+        serialized,
+        json!({
+            "id": "acme.tests.derive_runtime.registered_serde_task",
+            "id_source": "explicit",
+            "name": "registered_serde_task",
+            "version": "1.2.3",
+            "description": "Constructs a task from JSON input",
+            "execution_mode": "async",
+            "connection_plugin_name": null,
+            "processor_names": ["audit"],
+            "retry": null,
+            "input_schema": null,
+            "constructible": true
+        })
+    );
 }
 
 #[test]

--- a/genja-core/tests/derive_runtime.rs
+++ b/genja-core/tests/derive_runtime.rs
@@ -321,6 +321,36 @@ impl RegisteredSchemaTask {
     }
 }
 
+#[derive(serde::Deserialize)]
+struct RegisteredOverrideMetadataTask {
+    options: Value,
+}
+
+#[genja_task(
+    name = "registered_override_metadata_task",
+    connection_plugin_name = "ssh",
+    retry(allow = true, max_attempts = 3, delay_ms = 500),
+    session_verification(max_attempts = 3, delay_ms = 2000),
+    registration(
+        id = "acme.tests.derive_runtime.registered_override_metadata_task",
+        version = "1.0.0",
+        description = "Provides authored runtime metadata for override tests"
+    )
+)]
+impl RegisteredOverrideMetadataTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+
+    fn options(&self) -> Option<&Value> {
+        Some(&self.options)
+    }
+}
+
 #[test]
 fn genja_task_generates_task_info_from_metadata() {
     let task = AsyncTask {
@@ -462,6 +492,87 @@ fn genja_task_compiled_registry_creates_task_from_json_spec() {
 
     assert_eq!(task.name(), "registered_serde_task");
     assert_eq!(task.options(), Some(&json!({ "source": "json-spec" })));
+}
+
+#[test]
+fn genja_task_compiled_registry_applies_task_spec_runtime_overrides() {
+    let task = create_compiled_task_from_spec_str(
+        r#"
+task: acme.tests.derive_runtime.registered_override_metadata_task@1.0.0
+input:
+  options:
+    source: overrides
+overrides:
+  retry:
+    allow: false
+    max_attempts: 2
+    delay_ms: 250
+  session_verification:
+    max_attempts: 2
+    delay_ms: 1000
+"#,
+    )
+    .expect("task spec with runtime overrides should construct task");
+
+    assert_eq!(task.name(), "registered_override_metadata_task");
+    assert_eq!(task.options(), Some(&json!({ "source": "overrides" })));
+    let retry = task
+        .retry_config()
+        .expect("retry override should be present");
+    assert_eq!(retry.allow(), Some(false));
+    assert_eq!(retry.max_attempts(), Some(2));
+    assert_eq!(retry.delay_ms(), Some(250));
+    let session_verification = task
+        .session_verification_config()
+        .expect("session verification override should be present");
+    assert_eq!(session_verification.max_attempts(), 2);
+    assert_eq!(session_verification.delay_ms(), 1000);
+}
+
+#[test]
+fn genja_task_compiled_registry_preserves_authored_metadata_without_spec_overrides() {
+    let task = create_compiled_task_from_spec_str(
+        r#"
+task: acme.tests.derive_runtime.registered_override_metadata_task@1.0.0
+input:
+  options:
+    source: authored
+"#,
+    )
+    .expect("task spec without runtime overrides should construct task");
+
+    let retry = task
+        .retry_config()
+        .expect("authored retry config should be present");
+    assert_eq!(retry.allow(), Some(true));
+    assert_eq!(retry.max_attempts(), Some(3));
+    assert_eq!(retry.delay_ms(), Some(500));
+    let session_verification = task
+        .session_verification_config()
+        .expect("authored session verification should be present");
+    assert_eq!(session_verification.max_attempts(), 3);
+    assert_eq!(session_verification.delay_ms(), 2000);
+}
+
+#[test]
+fn genja_task_compiled_registry_rejects_invalid_task_spec_override() {
+    let error = create_compiled_task_from_spec_str(
+        r#"
+task: acme.tests.derive_runtime.registered_override_metadata_task@1.0.0
+input:
+  options: {}
+overrides:
+  processors: ["audit"]
+"#,
+    )
+    .expect_err("unsupported override should be rejected");
+
+    assert!(matches!(
+        error,
+        genja_core::task::TaskSpecConstructionError::InvalidSpec(
+            genja_core::task::TaskSpecError::InvalidOverride { .. }
+        )
+    ));
 }
 
 #[test]

--- a/genja-core/tests/ui_genja_task/fail/invalid_registration_id.rs
+++ b/genja-core/tests/ui_genja_task/fail/invalid_registration_id.rs
@@ -1,0 +1,22 @@
+use genja_core::genja_task;
+
+#[derive(serde::Deserialize)]
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(id = "Acme.Tests.BadTask")
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/invalid_registration_id.stderr
+++ b/genja-core/tests/ui_genja_task/fail/invalid_registration_id.stderr
@@ -1,0 +1,5 @@
+error: invalid registration `id`: id segments must start with an ASCII lowercase letter or digit
+ --> tests/ui_genja_task/fail/invalid_registration_id.rs:8:23
+  |
+8 |     registration(id = "Acme.Tests.BadTask")
+  |                       ^^^^^^^^^^^^^^^^^^^^

--- a/genja-core/tests/ui_genja_task/fail/invalid_registration_version.rs
+++ b/genja-core/tests/ui_genja_task/fail/invalid_registration_version.rs
@@ -1,0 +1,25 @@
+use genja_core::genja_task;
+
+#[derive(serde::Deserialize)]
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_task",
+        version = "latest"
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/invalid_registration_version.stderr
+++ b/genja-core/tests/ui_genja_task/fail/invalid_registration_version.stderr
@@ -1,0 +1,5 @@
+error: invalid registration `version`: unexpected character 'l' while parsing major version number
+  --> tests/ui_genja_task/fail/invalid_registration_version.rs:10:19
+   |
+10 |         version = "latest"
+   |                   ^^^^^^^^

--- a/genja-core/tests/ui_genja_task/fail/missing_registration_id.rs
+++ b/genja-core/tests/ui_genja_task/fail/missing_registration_id.rs
@@ -1,0 +1,22 @@
+use genja_core::genja_task;
+
+#[derive(serde::Deserialize)]
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(version = "1.2.3")
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/missing_registration_id.stderr
+++ b/genja-core/tests/ui_genja_task/fail/missing_registration_id.stderr
@@ -1,0 +1,10 @@
+error: `registration(...)` requires `id = "..."`
+ --> tests/ui_genja_task/fail/missing_registration_id.rs:6:1
+  |
+6 | / #[genja_task(
+7 | |     name = "bad_task",
+8 | |     registration(version = "1.2.3")
+9 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `genja_task` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/genja-core/tests/ui_genja_task/fail/registration_custom_missing_path.rs
+++ b/genja-core/tests/ui_genja_task/fail/registration_custom_missing_path.rs
@@ -1,0 +1,24 @@
+use genja_core::genja_task;
+
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_custom_task",
+        factory = custom
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/registration_custom_missing_path.stderr
+++ b/genja-core/tests/ui_genja_task/fail/registration_custom_missing_path.stderr
@@ -1,0 +1,5 @@
+error: `factory = custom(...)` requires a factory function path
+ --> tests/ui_genja_task/fail/registration_custom_missing_path.rs:9:19
+  |
+9 |         factory = custom
+  |                   ^^^^^^

--- a/genja-core/tests/ui_genja_task/fail/registration_custom_wrong_return.rs
+++ b/genja-core/tests/ui_genja_task/fail/registration_custom_wrong_return.rs
@@ -1,0 +1,29 @@
+use genja_core::genja_task;
+use serde_json::Value;
+
+struct BadTask;
+
+fn create_bad_task(_input: Value) -> Result<(), genja_core::task::TaskRegistrationError> {
+    Ok(())
+}
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_custom_return_task",
+        factory = custom(create_bad_task)
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/registration_custom_wrong_return.stderr
+++ b/genja-core/tests/ui_genja_task/fail/registration_custom_wrong_return.stderr
@@ -1,0 +1,13 @@
+error[E0308]: `?` operator has incompatible types
+  --> tests/ui_genja_task/fail/registration_custom_wrong_return.rs:10:1
+   |
+10 | / #[genja_task(
+11 | |     name = "bad_task",
+12 | |     registration(
+13 | |         id = "acme.tests.bad_custom_return_task",
+...  |
+16 | | )]
+   | |__^ expected `BadTask`, found `()`
+   |
+   = note: `?` operator cannot convert from `()` to `BadTask`
+   = note: this error originates in the attribute macro `genja_task` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/genja-core/tests/ui_genja_task/fail/registration_missing_default.rs
+++ b/genja-core/tests/ui_genja_task/fail/registration_missing_default.rs
@@ -1,0 +1,24 @@
+use genja_core::genja_task;
+
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_default_task",
+        factory = "default"
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/registration_missing_default.stderr
+++ b/genja-core/tests/ui_genja_task/fail/registration_missing_default.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `BadTask: Default` is not satisfied
+  --> tests/ui_genja_task/fail/registration_missing_default.rs:12:6
+   |
+12 | impl BadTask {
+   |      ^^^^^^^ the trait `Default` is not implemented for `BadTask`
+   |
+help: consider annotating `BadTask` with `#[derive(Default)]`
+   |
+3  + #[derive(Default)]
+4  | struct BadTask;
+   |

--- a/genja-core/tests/ui_genja_task/fail/registration_missing_deserialize.rs
+++ b/genja-core/tests/ui_genja_task/fail/registration_missing_deserialize.rs
@@ -1,0 +1,21 @@
+use genja_core::genja_task;
+use genja_core::inventory::Host;
+use genja_core::task::{HostTaskResult, TaskRuntimeContext, TaskSuccess};
+
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(id = "acme.tests.bad_task")
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/registration_missing_deserialize.stderr
+++ b/genja-core/tests/ui_genja_task/fail/registration_missing_deserialize.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `BadTask: serde::de::DeserializeOwned` is not satisfied
+  --> tests/ui_genja_task/fail/registration_missing_deserialize.rs:7:1
+   |
+7  | / #[genja_task(
+8  | |     name = "bad_task",
+9  | |     registration(id = "acme.tests.bad_task")
+10 | | )]
+   | |__^ the trait `for<'de> genja_core::serde::Deserialize<'de>` is not implemented for `BadTask`
+   |
+   = help: the following other types implement trait `genja_core::serde::Deserialize<'de>`:
+             &'a Path
+             &'a [u8]
+             &'a ron::value::raw::RawValue
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+           and $N others
+   = note: required for `BadTask` to implement `DeserializeOwned`
+note: required by a bound in `from_value`
+  --> $CARGO/serde_json-$VERSION/src/value/mod.rs
+   |
+   | pub fn from_value<T>(value: Value) -> Result<T, Error>
+   |        ---------- required by a bound in this function
+   | where
+   |     T: DeserializeOwned,
+   |        ^^^^^^^^^^^^^^^^ required by this bound in `from_value`
+   = note: this error originates in the attribute macro `genja_task` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/genja-core/tests/ui_genja_task/fail/registration_schema_missing_json_schema.rs
+++ b/genja-core/tests/ui_genja_task/fail/registration_schema_missing_json_schema.rs
@@ -1,0 +1,27 @@
+use genja_core::genja_task;
+
+#[derive(serde::Deserialize)]
+struct BadTask {
+    name: String,
+}
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_schema_task",
+        schema = "schemars"
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new().with_summary(self.name.clone()),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/registration_schema_missing_json_schema.stderr
+++ b/genja-core/tests/ui_genja_task/fail/registration_schema_missing_json_schema.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `BadTask: JsonSchema` is not satisfied
+  --> tests/ui_genja_task/fail/registration_schema_missing_json_schema.rs:15:6
+   |
+8  | / #[genja_task(
+9  | |     name = "bad_task",
+10 | |     registration(
+11 | |         id = "acme.tests.bad_schema_task",
+...  |
+14 | | )]
+   | |__- required by a bound introduced by this call
+15 |   impl BadTask {
+   |        ^^^^^^^ the trait `JsonSchema` is not implemented for `BadTask`
+   |
+   = help: the following other types implement trait `JsonSchema`:
+             &'a T
+             &'a mut T
+             ()
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+           and $N others
+note: required by a bound in `SchemaGenerator::into_root_schema_for`
+  --> $CARGO/schemars-$VERSION/src/generate.rs
+   |
+   |     pub fn into_root_schema_for<T: ?Sized + JsonSchema>(mut self) -> Schema {
+   |                                             ^^^^^^^^^^ required by this bound in `SchemaGenerator::into_root_schema_for`

--- a/genja-core/tests/ui_genja_task/fail/registration_schema_nested_missing_json_schema.rs
+++ b/genja-core/tests/ui_genja_task/fail/registration_schema_nested_missing_json_schema.rs
@@ -1,0 +1,32 @@
+use genja_core::genja_task;
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct BadTask {
+    rules: Vec<BadRule>,
+}
+
+#[derive(serde::Deserialize)]
+struct BadRule {
+    action: String,
+}
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_nested_schema_task",
+        schema = "schemars"
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new().with_summary(self.rules.len().to_string()),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/registration_schema_nested_missing_json_schema.stderr
+++ b/genja-core/tests/ui_genja_task/fail/registration_schema_nested_missing_json_schema.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `BadRule: JsonSchema` is not satisfied
+ --> tests/ui_genja_task/fail/registration_schema_nested_missing_json_schema.rs:5:12
+  |
+5 |     rules: Vec<BadRule>,
+  |            ^^^^^^^^^^^^ the trait `JsonSchema` is not implemented for `BadRule`
+  |
+  = help: the following other types implement trait `JsonSchema`:
+            &'a T
+            &'a mut T
+            ()
+            (T0, T1)
+            (T0, T1, T2)
+            (T0, T1, T2, T3)
+            (T0, T1, T2, T3, T4)
+            (T0, T1, T2, T3, T4, T5)
+          and $N others
+  = note: required for `Vec<BadRule>` to implement `JsonSchema`

--- a/genja-core/tests/ui_genja_task/fail/unknown_registration_key.rs
+++ b/genja-core/tests/ui_genja_task/fail/unknown_registration_key.rs
@@ -1,0 +1,25 @@
+use genja_core::genja_task;
+
+#[derive(serde::Deserialize)]
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_task",
+        owner = "network"
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/unknown_registration_key.stderr
+++ b/genja-core/tests/ui_genja_task/fail/unknown_registration_key.stderr
@@ -1,0 +1,5 @@
+error: unsupported registration key; expected `id`, `version`, `description`, or `factory`
+  --> tests/ui_genja_task/fail/unknown_registration_key.rs:10:9
+   |
+10 |         owner = "network"
+   |         ^^^^^

--- a/genja-core/tests/ui_genja_task/fail/unknown_registration_key.stderr
+++ b/genja-core/tests/ui_genja_task/fail/unknown_registration_key.stderr
@@ -1,4 +1,4 @@
-error: unsupported registration key; expected `id`, `version`, `description`, or `factory`
+error: unsupported registration key; expected `id`, `version`, `description`, `factory`, or `schema`
   --> tests/ui_genja_task/fail/unknown_registration_key.rs:10:9
    |
 10 |         owner = "network"

--- a/genja-core/tests/ui_genja_task/fail/unsupported_registration_factory.rs
+++ b/genja-core/tests/ui_genja_task/fail/unsupported_registration_factory.rs
@@ -1,0 +1,25 @@
+use genja_core::genja_task;
+
+#[derive(serde::Deserialize)]
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_task",
+        factory = "custom"
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/unsupported_registration_factory.stderr
+++ b/genja-core/tests/ui_genja_task/fail/unsupported_registration_factory.stderr
@@ -1,4 +1,4 @@
-error: `registration(factory = ...)` currently supports only `"serde"`; omit `factory` to use serde
+error: use `factory = custom(path)` to configure a custom registration factory
   --> tests/ui_genja_task/fail/unsupported_registration_factory.rs:10:19
    |
 10 |         factory = "custom"

--- a/genja-core/tests/ui_genja_task/fail/unsupported_registration_factory.stderr
+++ b/genja-core/tests/ui_genja_task/fail/unsupported_registration_factory.stderr
@@ -1,0 +1,5 @@
+error: `registration(factory = ...)` currently supports only `"serde"`; omit `factory` to use serde
+  --> tests/ui_genja_task/fail/unsupported_registration_factory.rs:10:19
+   |
+10 |         factory = "custom"
+   |                   ^^^^^^^^

--- a/genja-core/tests/ui_genja_task/fail/unsupported_registration_schema.rs
+++ b/genja-core/tests/ui_genja_task/fail/unsupported_registration_schema.rs
@@ -1,0 +1,25 @@
+use genja_core::genja_task;
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct BadTask;
+
+#[genja_task(
+    name = "bad_task",
+    registration(
+        id = "acme.tests.bad_schema_task",
+        schema = "jsonschema"
+    )
+)]
+impl BadTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/fail/unsupported_registration_schema.stderr
+++ b/genja-core/tests/ui_genja_task/fail/unsupported_registration_schema.stderr
@@ -1,0 +1,5 @@
+error: `registration(schema = ...)` supports only `"schemars"`
+  --> tests/ui_genja_task/fail/unsupported_registration_schema.rs:10:18
+   |
+10 |         schema = "jsonschema"
+   |                  ^^^^^^^^^^^^

--- a/genja-core/tests/ui_genja_task/pass/registration.rs
+++ b/genja-core/tests/ui_genja_task/pass/registration.rs
@@ -1,0 +1,34 @@
+use genja_core::genja_task;
+use genja_core::inventory::Host;
+use genja_core::task::{HostTaskResult, TaskRuntimeContext, TaskSuccess};
+use serde_json::Value;
+
+#[derive(serde::Deserialize)]
+struct RegisteredTask {
+    options: Value,
+}
+
+#[genja_task(
+    name = "registered_task",
+    registration(
+        id = "acme.tests.registered_task",
+        version = "1.2.3",
+        description = "Registered task",
+        factory = "serde"
+    )
+)]
+impl RegisteredTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new()))
+    }
+
+    fn options(&self) -> Option<&Value> {
+        Some(&self.options)
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/pass/registration_factories.rs
+++ b/genja-core/tests/ui_genja_task/pass/registration_factories.rs
@@ -1,0 +1,60 @@
+use genja_core::genja_task;
+use serde_json::Value;
+
+#[derive(Default)]
+struct DefaultFactoryTask;
+
+#[genja_task(
+    name = "default_factory_task",
+    registration(
+        id = "acme.tests.default_factory_task",
+        factory = "default"
+    )
+)]
+impl DefaultFactoryTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new(),
+        ))
+    }
+}
+
+struct CustomFactoryTask {
+    value: String,
+}
+
+fn create_custom_factory_task(
+    input: Value,
+) -> Result<CustomFactoryTask, genja_core::task::TaskRegistrationError> {
+    let value = input
+        .get("value")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    Ok(CustomFactoryTask { value })
+}
+
+#[genja_task(
+    name = "custom_factory_task",
+    registration(
+        id = "acme.tests.custom_factory_task",
+        factory = custom(create_custom_factory_task)
+    )
+)]
+impl CustomFactoryTask {
+    async fn start_async(
+        &self,
+        _host: &genja_core::inventory::Host,
+        _context: &genja_core::task::TaskRuntimeContext,
+    ) -> Result<genja_core::task::HostTaskResult, genja_core::task::TaskError> {
+        Ok(genja_core::task::HostTaskResult::passed(
+            genja_core::task::TaskSuccess::new().with_summary(self.value.clone()),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja-core/tests/ui_genja_task/pass/registration_schema.rs
+++ b/genja-core/tests/ui_genja_task/pass/registration_schema.rs
@@ -1,0 +1,35 @@
+use genja_core::genja_task;
+use genja_core::inventory::Host;
+use genja_core::task::{HostTaskResult, TaskRuntimeContext, TaskSuccess};
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct SchemaTask {
+    name: String,
+    rules: Vec<SchemaRule>,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct SchemaRule {
+    action: String,
+}
+
+#[genja_task(
+    name = "schema_task",
+    registration(
+        id = "acme.tests.schema_task",
+        schema = "schemars"
+    )
+)]
+impl SchemaTask {
+    async fn start_async(
+        &self,
+        _host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, genja_core::task::TaskError> {
+        Ok(HostTaskResult::passed(
+            TaskSuccess::new().with_summary(format!("{}:{}", self.name, self.rules.len())),
+        ))
+    }
+}
+
+fn main() {}

--- a/genja/Cargo.toml
+++ b/genja/Cargo.toml
@@ -20,3 +20,7 @@ log = "0.4.27"
 regex = "1.12.2"
 serde_json = "1.0.142"
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
+
+[dev-dependencies]
+schemars = "1.0.4"
+serde = { version = "1.0.219", features = ["derive"] }

--- a/genja/examples/task_registration.rs
+++ b/genja/examples/task_registration.rs
@@ -1,0 +1,94 @@
+use genja::genja_core::inventory::Host;
+use genja::genja_core::task::{
+    HostTaskResult, TaskError, TaskInfo, TaskRuntimeContext, TaskSuccess,
+    create_compiled_task_by_identity, get_compiled_task_descriptor_by_identity,
+    list_compiled_tasks,
+};
+use genja::genja_task;
+use serde_json::json;
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct BackupRule {
+    path: String,
+    recursive: bool,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct BackupConfig {
+    backup_path: String,
+    compress: bool,
+    rules: Vec<BackupRule>,
+}
+
+#[genja_task(
+    name = "backup_config",
+    connection_plugin_name = "ssh",
+    registration(
+        id = "acme.examples.backup_config",
+        version = "1.0.0",
+        description = "Backs up selected paths from a network device",
+        schema = "schemars"
+    )
+)]
+impl BackupConfig {
+    async fn start_async(
+        &self,
+        host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, TaskError> {
+        let first_rule = self
+            .rules
+            .first()
+            .map(|rule| format!("{} recursive={}", rule.path, rule.recursive))
+            .unwrap_or_else(|| "no paths".to_string());
+
+        Ok(HostTaskResult::passed(TaskSuccess::new().with_summary(
+            format!(
+                "backing up {} to {} compress={} first_rule={}",
+                host.hostname().unwrap_or("host"),
+                self.backup_path,
+                self.compress,
+                first_rule
+            ),
+        )))
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let identity = "acme.examples.backup_config@1.0.0";
+
+    println!("Registered task identities:");
+    for descriptor in list_compiled_tasks()? {
+        println!(
+            "- {}@{} ({})",
+            descriptor.id, descriptor.version, descriptor.name
+        );
+    }
+
+    let descriptor = get_compiled_task_descriptor_by_identity(identity)?;
+    println!("\nDescriptor:");
+    println!("{}", serde_json::to_string_pretty(&descriptor)?);
+
+    if let Some(schema) = &descriptor.input_schema {
+        println!("\nInput schema:");
+        println!("{}", serde_json::to_string_pretty(schema)?);
+    }
+
+    let task = create_compiled_task_by_identity(
+        identity,
+        json!({
+            "backup_path": "/tmp/configs",
+            "compress": true,
+            "rules": [
+                {
+                    "path": "/etc/network",
+                    "recursive": true
+                }
+            ]
+        }),
+    )?;
+
+    println!("\nCreated task: {}", task.name());
+
+    Ok(())
+}

--- a/genja/examples/task_registration_custom_factory.rs
+++ b/genja/examples/task_registration_custom_factory.rs
@@ -1,0 +1,88 @@
+use genja::genja_core::inventory::Host;
+use genja::genja_core::task::{
+    HostTaskResult, TaskError, TaskInfo, TaskRegistrationError, TaskRuntimeContext, TaskSuccess,
+    create_compiled_task_by_identity, get_compiled_task_descriptor_by_identity,
+};
+use genja::genja_task;
+use serde_json::Value;
+
+struct ConfigureAcl {
+    acl_name: String,
+    secret_token: String,
+}
+
+fn create_configure_acl(input: Value) -> Result<ConfigureAcl, TaskRegistrationError> {
+    let acl_name = input.get("acl").and_then(Value::as_str).ok_or_else(|| {
+        TaskRegistrationError::InvalidInput {
+            id: "acme.examples.configure_acl".to_string(),
+            version: "1.0.0".to_string(),
+            message: "`acl` is required".to_string(),
+        }
+    })?;
+    let token_obfuscated = input
+        .get("token_obfuscated")
+        .and_then(Value::as_str)
+        .ok_or_else(|| TaskRegistrationError::InvalidInput {
+            id: "acme.examples.configure_acl".to_string(),
+            version: "1.0.0".to_string(),
+            message: "`token_obfuscated` is required".to_string(),
+        })?;
+
+    Ok(ConfigureAcl {
+        acl_name: acl_name.to_string(),
+        secret_token: token_obfuscated.chars().rev().collect(),
+    })
+}
+
+#[genja_task(
+    name = "configure_acl",
+    connection_plugin_name = "ssh",
+    registration(
+        id = "acme.examples.configure_acl",
+        version = "1.0.0",
+        description = "Configures an ACL after preparing custom input",
+        factory = custom(create_configure_acl)
+    )
+)]
+impl ConfigureAcl {
+    async fn start_async(
+        &self,
+        host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, TaskError> {
+        Ok(HostTaskResult::passed(TaskSuccess::new().with_summary(
+            format!(
+                "configured {} on {} using a {} byte token",
+                self.acl_name,
+                host.hostname().unwrap_or("host"),
+                self.secret_token.len()
+            ),
+        )))
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let identity = "acme.examples.configure_acl@1.0.0";
+
+    let descriptor = get_compiled_task_descriptor_by_identity(identity)?;
+    println!("Descriptor:");
+    println!("{}", serde_json::to_string_pretty(&descriptor)?);
+
+    let task = create_compiled_task_by_identity(
+        identity,
+        serde_json::json!({
+            "acl": "edge-inbound",
+            "token_obfuscated": "terces"
+        }),
+    )?;
+
+    println!("\nCreated task: {}", task.name());
+
+    let error = match create_compiled_task_by_identity(identity, serde_json::json!({})) {
+        Ok(_) => panic!("custom factory should reject missing fields"),
+        Err(error) => error,
+    };
+    println!("\nRejected invalid input: {error}");
+
+    Ok(())
+}

--- a/genja/examples/task_registration_spec.rs
+++ b/genja/examples/task_registration_spec.rs
@@ -62,6 +62,14 @@ input:
   rules:
     - path: /etc/network
       recursive: true
+overrides:
+  retry:
+    allow: true
+    max_attempts: 2
+    delay_ms: 250
+  session_verification:
+    max_attempts: 2
+    delay_ms: 1000
 "#;
 
     let spec = TaskSpec::parse_auto(yaml_spec)?;
@@ -69,6 +77,21 @@ input:
 
     let yaml_task = create_compiled_task_from_spec_str(yaml_spec)?;
     println!("Created from YAML spec: {}", yaml_task.name());
+    if let Some(retry) = yaml_task.retry_config() {
+        println!(
+            "Retry override: allow={:?} max_attempts={:?} delay_ms={:?}",
+            retry.allow(),
+            retry.max_attempts(),
+            retry.delay_ms()
+        );
+    }
+    if let Some(session_verification) = yaml_task.session_verification_config() {
+        println!(
+            "Session verification override: max_attempts={} delay_ms={}",
+            session_verification.max_attempts(),
+            session_verification.delay_ms()
+        );
+    }
 
     let json_spec = r#"
 {

--- a/genja/examples/task_registration_spec.rs
+++ b/genja/examples/task_registration_spec.rs
@@ -1,0 +1,96 @@
+//! Demonstrates constructing a registered task from YAML and JSON spec strings.
+
+use genja::genja_core::inventory::Host;
+use genja::genja_core::task::{
+    HostTaskResult, TaskError, TaskInfo, TaskRuntimeContext, TaskSpec, TaskSuccess,
+    create_compiled_task_from_spec_str, create_compiled_task_from_spec_str_with_format,
+};
+use genja::genja_task;
+
+#[derive(serde::Deserialize)]
+struct BackupRule {
+    path: String,
+    recursive: bool,
+}
+
+#[derive(serde::Deserialize)]
+struct BackupConfig {
+    backup_path: String,
+    compress: bool,
+    rules: Vec<BackupRule>,
+}
+
+#[genja_task(
+    name = "backup_config_from_spec",
+    connection_plugin_name = "ssh",
+    registration(
+        id = "acme.examples.backup_config_from_spec",
+        version = "1.0.0",
+        description = "Constructs a backup task from a declarative spec"
+    )
+)]
+impl BackupConfig {
+    async fn start_async(
+        &self,
+        host: &Host,
+        _context: &TaskRuntimeContext,
+    ) -> Result<HostTaskResult, TaskError> {
+        let first_rule = self
+            .rules
+            .first()
+            .map(|rule| format!("{} recursive={}", rule.path, rule.recursive))
+            .unwrap_or_else(|| "no paths".to_string());
+
+        Ok(HostTaskResult::passed(TaskSuccess::new().with_summary(
+            format!(
+                "backing up {} to {} compress={} first_rule={}",
+                host.hostname().unwrap_or("host"),
+                self.backup_path,
+                self.compress,
+                first_rule
+            ),
+        )))
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let yaml_spec = r#"
+task: acme.examples.backup_config_from_spec@1.0.0
+input:
+  backup_path: /tmp/configs
+  compress: true
+  rules:
+    - path: /etc/network
+      recursive: true
+"#;
+
+    let spec = TaskSpec::parse_auto(yaml_spec)?;
+    println!("Parsed spec for {}", spec.task);
+
+    let yaml_task = create_compiled_task_from_spec_str(yaml_spec)?;
+    println!("Created from YAML spec: {}", yaml_task.name());
+
+    let json_spec = r#"
+{
+  "task": "acme.examples.backup_config_from_spec@1.0.0",
+  "input": {
+    "backup_path": "/tmp/configs",
+    "compress": false,
+    "rules": [
+      {
+        "path": "/etc/hosts",
+        "recursive": false
+      }
+    ]
+  }
+}
+"#;
+
+    let json_task = create_compiled_task_from_spec_str_with_format(
+        json_spec,
+        genja::genja_core::task::TaskSpecFormat::Json,
+    )?;
+    println!("Created from JSON spec: {}", json_task.name());
+
+    Ok(())
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -13,7 +13,10 @@ nav = [
   {"Settings" = "settings.md"},
   {"API Surface" = "api-surface.md"},
   {"Inventory" = "inventory.md"},
-  {"Tasks" = "tasks.md"},
+  {"Tasks" = [
+    "tasks.md",
+    {"Rust Task Registration" = "task-registration.md"},
+  ]},
   {"Runners" = "runners.md"},
   {"Plugins" = [
     "plugins/index.md",


### PR DESCRIPTION
closes #91 

## Summary

Adds Rust task registration and discovery support through `#[genja_task]`, including descriptor metadata, compiled-task registry lookup, JSON construction factories, input schemas, declarative task specs, and narrow runtime-policy overrides.

## What Changed

- Added task descriptor, factory, registry, and compiled registry APIs in `genja-core`.
- Added macro-generated task registration for Rust tasks.
- Added stable task identity handling with `<task-id>@<task-version>`.
- Added generated local discovery IDs for unregistered tasks.
- Added serde, default, and custom factory strategies.
- Added optional schemars input schema generation.
- Added `TaskSpec` for YAML/JSON single-task construction specs.
- Added task spec runtime overrides for retry and session verification.
- Added duplicate registration detection and deterministic lookup behavior.
- Added docs, changelog entries, and runnable examples.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --exclude genja-core-python`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `zensical build`
- `cargo run -p genja --example task_registration`
- `cargo run -p genja --example task_registration_custom_factory`
- `cargo run -p genja --example task_registration_spec`
- Python PDM checks passed locally
